### PR TITLE
Avoid talking to Xero if PushAlterMapped() sets  $save to FALSE

### DIFF
--- a/CRM/Civixero/BankTransaction.php
+++ b/CRM/Civixero/BankTransaction.php
@@ -36,6 +36,9 @@ class CRM_Civixero_BankTransaction extends CRM_Civixero_Invoice {
    * @return array
    */
   protected function pushToXero($accountsInvoice, $connector_id) {
+    if ($accountsInvoice === FALSE) {
+      return FALSE;
+    }
     $result = $this->getSingleton($connector_id)->BankTransactions($accountsInvoice);
     return $result;
   }

--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -110,9 +110,18 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
         try {
           $accountsContactID = !empty($record['accounts_contact_id']) ? $record['accounts_contact_id'] : NULL;
           $accountsContact = $this->mapToAccounts($record['api.contact.get']['values'][0], $accountsContactID);
-          $result = $this->getSingleton($params['connector_id'])->Contacts($accountsContact);
-          $responseErrors = $this->validateResponse($result);
-          if ($responseErrors) {
+          if ($accountsContact === FALSE) {
+            $result = FALSE;
+            $responseErrors = array();
+          }
+          else {
+            $result = $this->getSingleton($params['connector_id'])->Contacts($accountsContact);
+            $responseErrors = $this->validateResponse($result);
+          }
+          if ($result === FALSE) {
+            unset($record['accounts_modified_date']);
+          }
+          elseif ($responseErrors) {
             $record['error_data'] = json_encode($responseErrors);
           }
           else {

--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -397,29 +397,35 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
    * @throws \CiviCRM_API3_Exception
    */
   protected function savePushResponse($result, $record) {
-    $responseErrors = $this->validateResponse($result);
-    if ($responseErrors) {
-      if (in_array('Invoice not of valid status for modification', $responseErrors)) {
-        // we can't update in Xero as it is approved or voided so let's not keep trying
-        $record['accounts_needs_update'] = 0;
-      }
-      $record['error_data'] = json_encode($responseErrors);
+    if ($result === FALSE) {
+      $responseErrors = array();
+      $record['accounts_needs_update'] = 0;
     }
     else {
-      $record['error_data'] = 'null';
-      if (empty($record['accounts_invoice_id'])) {
-        // For bank transactions this would be
-        // $record['accounts_invoice_id'] = $result['Invoices']['Invoice']['InvoiceID'];
-        $record['accounts_invoice_id'] = $result['BankTransactions']['BankTransaction']['BankTransactionID'];
-        $record['accounts_modified_date'] = $result['BankTransactions']['BankTransaction']['UpdatedDateUTC'];
-        $record['accounts_data'] = json_encode($result['BankTransactions']['BankTransaction']);
-        $record['accounts_status_id'] = $this->mapStatus($result['BankTransactions']['BankTransaction']['Status']);
+      $responseErrors = $this->validateResponse($result);
+      if ($responseErrors) {
+        if (in_array('Invoice not of valid status for modification', $responseErrors)) {
+          // we can't update in Xero as it is approved or voided so let's not keep trying
+          $record['accounts_needs_update'] = 0;
+        }
+        $record['error_data'] = json_encode($responseErrors);
       }
       else {
-        $record['accounts_modified_date'] = $result['Invoices']['Invoice']['UpdatedDateUTC'];
-        $record['accounts_data'] = json_encode($result['Invoices']['Invoice']);
-        $record['accounts_status_id'] = $this->mapStatus($result['Invoices']['Invoice']['Status']);
-        $record['accounts_needs_update'] = 0;
+        $record['error_data'] = 'null';
+        if (empty($record['accounts_invoice_id'])) {
+          // For bank transactions this would be
+          // $record['accounts_invoice_id'] = $result['Invoices']['Invoice']['InvoiceID'];
+          $record['accounts_invoice_id'] = $result['BankTransactions']['BankTransaction']['BankTransactionID'];
+          $record['accounts_modified_date'] = $result['BankTransactions']['BankTransaction']['UpdatedDateUTC'];
+          $record['accounts_data'] = json_encode($result['BankTransactions']['BankTransaction']);
+          $record['accounts_status_id'] = $this->mapStatus($result['BankTransactions']['BankTransaction']['Status']);
+        }
+        else {
+          $record['accounts_modified_date'] = $result['Invoices']['Invoice']['UpdatedDateUTC'];
+          $record['accounts_data'] = json_encode($result['Invoices']['Invoice']);
+          $record['accounts_status_id'] = $this->mapStatus($result['Invoices']['Invoice']['Status']);
+          $record['accounts_needs_update'] = 0;
+        }
       }
     }
     //this will update the last sync date & anything hook-modified
@@ -442,6 +448,9 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
    * @return array
    */
   protected function pushToXero($accountsInvoice, $connector_id) {
+    if ($accountsInvoice === FALSE) {
+      return FALSE;
+    }
     $result = $this->getSingleton($connector_id)->Invoices($accountsInvoice);
     return $result;
   }


### PR DESCRIPTION
As discussed in issue #11 

To understand the changes, $accountInvoice and $result are FALSE when the hook returns $save as FALSE.

 - For Contacts I elected to change the push() function.
 - For Invoices I changed the functions called by push() [essentially so savePushResponse() got called to update the account_invoice]. 
 - I don't push Bank Transactions so I made the change analogous to the one for Invoices. You should be wary of that change as it's not tested.