### PR TITLE
Prevent Invoices that were DELETED or VOIDED in Xero from being pushed back

### DIFF
--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -351,6 +351,10 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
    * @throws \CiviCRM_API3_Exception
    */
   protected function getAccountsInvoice($record) {
+    if ($record['accounts_status_id'] == 3) {
+      return FALSE;
+    }
+
     $accountsInvoiceID = isset($record['accounts_invoice_id']) ? $record['accounts_invoice_id'] : NULL;
     $contributionID = $record['contribution_id'];
     $civiCRMInvoice = civicrm_api3('account_invoice', 'getderived', array(


### PR DESCRIPTION
This is an alternative implementation to solve issue #14 

The advantage of this approach is that the 'accounts_needs_update' flag is set back to '0'