### PR TITLE
Set accounts_needs_update to 0 when pulling contacts

### DIFF
--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -35,6 +35,7 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
             'plugin' => 'xero',
             'accounts_contact_id' => $contact['ContactID'],
             'accounts_data' => json_encode($contact),
+            'accounts_needs_update' => 0,
           );
           CRM_Accountsync_Hook::accountPullPreSave('contact', $contact, $save, $params);
           if (!$save) {


### PR DESCRIPTION
The recent database change to default accounts_needs_update to 1 means it needs to be set to 0 in cases where we don't want to update the accounts system.

When pulling contacts from Xero to CiviCRM, we don't need to update Xero again.

BTW, pulling invoices already sets accounts_needs_update to 0, so it's OK.