### PR TITLE
2 improvements when handling Xero's response after pushing an Invoice

### DIFF
--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -423,7 +423,7 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
       }
       else {
         $record['error_data'] = 'null';
-        if (empty($record['accounts_invoice_id'])) {
+        if (isset($result['BankTransactions'])) {
           // For bank transactions this would be
           // $record['accounts_invoice_id'] = $result['Invoices']['Invoice']['InvoiceID'];
           $record['accounts_invoice_id'] = $result['BankTransactions']['BankTransaction']['BankTransactionID'];
@@ -432,6 +432,9 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
           $record['accounts_status_id'] = $this->mapStatus($result['BankTransactions']['BankTransaction']['Status']);
         }
         else {
+          if (empty($record['accounts_invoice_id']) && !empty($result['Invoices']['Invoice']['InvoiceID'])) {
+            $record['accounts_invoice_id'] = $result['Invoices']['Invoice']['InvoiceID'];
+          }
           $record['accounts_modified_date'] = $result['Invoices']['Invoice']['UpdatedDateUTC'];
           $record['accounts_data'] = json_encode($result['Invoices']['Invoice']);
           $record['accounts_status_id'] = $this->mapStatus($result['Invoices']['Invoice']['Status']);


### PR DESCRIPTION
Improvements ...

1. Improve the Bank Transaction test
2. capture the Invoice Id if not yet set

Explanation ...

1. Looking at the if statement, the assignments all assume $result['BankTransactions'] is set. So it makes sense to test for this. Also $result is clearly not an Invoice if that is true.

2. The response to the push includes the Invoice Id so why not capture it? Saves us waiting for a pull. The change also protects against the unlikely (impossible?) case that the Invoice Id changes.