### PR TITLE
SUP-2549: Don't find matching contacts for the same contact id.

### DIFF
--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -129,6 +129,7 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
             /* When Xero returns an ID that matches an existing account_contact, update it instead. */
             $matching = civicrm_api('account_contact', 'getsingle', array(
                 'accounts_contact_id' => $result['Contacts']['Contact']['ContactID'],
+                'contact_id' => array('!=' => $record['contact_id']),
                 'plugin' => $this->_plugin,
                 'version' => 3,
               )
@@ -142,7 +143,7 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
                 $record['id'] = $matching['id'];
               }
               else {
-                throw new CiviCRM_API3_Exception(ts('Attempt to sync Contact %1 to Xero entry for existing Contact %2', array(1 => $record['contact_id'], 2 => $matching['contact_id'])));
+                throw new CiviCRM_API3_Exception(ts('Attempt to sync Contact %1 to Xero entry for existing Contact %2. ', array(1 => $record['contact_id'], 2 => $matching['contact_id']), NULL, $record));
               }
             }
 


### PR DESCRIPTION
Introduced a bug in #33 -- Should've checked that one more carefully.

One of our systems stopped pushing contacts altogether as too many of them were suddenly failing because they matched themselves.  This fixes that.

Sorry! 😳