### PR TITLE
Exposing the account sync error logs in the CiviCRM UI

### DIFF
--- a/CRM/Civixero/Page/AJAX.php
+++ b/CRM/Civixero/Page/AJAX.php
@@ -1,0 +1,35 @@
+<?php
+use CRM_Civixero_ExtensionUtil as E;
+
+class CRM_Civixero_Page_AJAX extends CRM_Core_Page {
+
+  public static function contactSyncErrors() {
+      $syncerrors = array();
+      if(CRM_Utils_Array::value('xeroerrorid', $_REQUEST)) {
+          $xeroerrorid = CRM_Utils_Type::escape($_REQUEST['xeroerrorid'], 'Integer');
+          $accountcontact = civicrm_api3("AccountContact","get", array(
+             "id"          => $xeroerrorid ,
+              "sequential" => TRUE,
+          ));
+          if($accountcontact["count"]) {
+              $accountcontact = $accountcontact["values"][0];
+              $syncerrors = $accountcontact["error_data"];
+              $syncerrors = json_decode($syncerrors, TRUE);
+          }
+      }
+      CRM_Utils_JSON::output($syncerrors);
+  }
+
+    public static function invoiceSyncErrors() {
+        $syncerrors = array();
+        if(CRM_Utils_Array::value('xeroerrorid', $_REQUEST)) {
+            $contactid = CRM_Utils_Type::escape($_REQUEST['xeroerrorid'], 'Integer');
+            $contributions = getContactContributions($contactid);
+            $invoices = getErroredInvoicesOfContributions($contributions);
+            foreach($invoices["values"] as $invoice) {
+                $syncerrors = array_merge($syncerrors, json_decode($invoice["error_data"], TRUE)) ;
+            }
+        }
+        CRM_Utils_JSON::output($syncerrors);
+    }
+}

--- a/CRM/Civixero/Page/XeroErrorLogs.php
+++ b/CRM/Civixero/Page/XeroErrorLogs.php
@@ -1,0 +1,119 @@
+<?php
+use CRM_Civixero_ExtensionUtil as E;
+
+class CRM_Civixero_Page_XeroErrorLogs extends CRM_Core_Page {
+
+    private $errorsFor = "contact";
+    private $pageTitle = "";
+
+    public function run() {
+        $this->setupPage();
+        $this->initializePager();
+        $this->assign('syncErrors', $this->getSyncErrors());
+        parent::run();
+    }
+
+    /**
+     * Function to setup page values
+     *
+     * @access protected
+     */
+    protected function setupPage() {
+        $for = CRM_Utils_Request::retrieve('for', 'String');
+        if($for == 'invoice') {
+            $this->errorsFor = $for;
+        }
+        $this->assign("errorsfor", $this->errorsFor);
+        CRM_Utils_System::setTitle(E::ts('Xero %1 error logs', array(1 => $this->errorsFor));
+        CRM_Core_Resources::singleton()->addStyleFile('nz.co.fuzion.civixero','css/civixero_styles.css');
+    }
+
+    /**
+     * Function to get the sync errors
+     *
+     * @return array $syncerrors
+     * @access protected
+     */
+    protected function getSyncErrors() {
+        $syncerrors = array();
+        list($offset, $limit) = $this->_pager->getOffsetAndRowCount();
+        if($this->errorsFor == "contact") {
+            $accountcontacts = civicrm_api3("AccountContact","get",array(
+                "error_data"  =>  array("<>" => ""),
+                "plugin"      =>  "xero",
+                "return"      => array("contact_id.display_name","accounts_contact_id","error_data","last_sync_date","contact_id"),
+                "options"     => array('limit' => $limit, 'offset' => $offset, 'sort' => 'id DESC'),
+            ));
+    
+            $accountcontacts = $accountcontacts["values"];
+            $this->formatErrors($accountcontacts);
+            $this->formatContactsInfo($accountcontacts);
+            return $accountcontacts;
+        }
+
+        $accountinvoices = civicrm_api3("AccountInvoice","get",array(
+            "error_data"  =>  array("<>" => ""),
+            "plugin"      =>  "xero",
+            "return"      => array("contribution_id","contribution_id.contact_id","contribution_id.contact_id.display_name","accounts_invoice_id","error_data","last_sync_date"),
+            "options"     => array('limit' => $limit, 'offset' => $offset),
+        ));
+        $accountinvoices = $accountinvoices["values"];
+        $this->formatErrors($accountinvoices);
+        $this->formatContactsInfo($accountinvoices);
+        return $accountinvoices;
+    }
+
+    /**
+     * Method to format JSON errors
+     *
+     * @access protected
+     */
+    protected function formatErrors(&$syncerrors) {
+        foreach($syncerrors as $index => $syncerror) {
+            $syncerrors[$index]["error_data"] = json_decode($syncerror["error_data"], TRUE);
+        }
+    }
+
+    /**
+     * Method to format Contacts Name
+     *
+     * @access protected
+     */
+    protected function formatContactsInfo(&$syncerrors) {
+        foreach($syncerrors as $index => $syncerror) {
+            if(array_key_exists("contact_id.display_name", $syncerror)) {
+                $syncerrors[$index]["contactname"] = $syncerror["contact_id.display_name"];
+            } else {
+                $syncerrors[$index]["contactname"] = $syncerror["contribution_id.contact_id.display_name"];
+            }
+
+            if(array_key_exists("contribution_id.contact_id", $syncerror)) {
+                $syncerrors[$index]["contact_id"] = $syncerror["contribution_id.contact_id"];
+            }
+        }
+    }
+
+    /**
+     * Method to initialize pager
+     *
+     * @access protected
+     */
+    protected function initializePager() {
+        $accountcontacts = civicrm_api3("AccountContact","getcount",array(
+            "error_data"  =>  array("<>" => ""),
+            "plugin"      =>  "xero"
+        ));
+        $totalitems = $accountcontacts;
+        $params           = array(
+            'total' => $totalitems,
+            'rowCount' => CRM_Utils_Pager::ROWCOUNT,
+            'status' => ts('Expense Claim Levels %%StatusMessage%%'),
+            'buttonBottom' => 'PagerBottomButton',
+            'buttonTop' => 'PagerTopButton',
+            'pageID' => $this->get(CRM_Utils_Pager::PAGE_ID),
+        );
+        $this->_pager = new CRM_Utils_Pager($params);
+        $this->assign_by_ref('pager', $this->_pager);
+    }
+
+}

--- a/CRM/Civixero/Page/XeroErrorLogs.php
+++ b/CRM/Civixero/Page/XeroErrorLogs.php
@@ -24,7 +24,7 @@ class CRM_Civixero_Page_XeroErrorLogs extends CRM_Core_Page {
             $this->errorsFor = $for;
         }
         $this->assign("errorsfor", $this->errorsFor);
-        CRM_Utils_System::setTitle(E::ts('Xero %1 error logs', array(1 => $this->errorsFor));
+        CRM_Utils_System::setTitle(E::ts('Xero %1 error logs', array(1 => $this->errorsFor)));
         CRM_Core_Resources::singleton()->addStyleFile('nz.co.fuzion.civixero','css/civixero_styles.css');
     }
 
@@ -44,7 +44,7 @@ class CRM_Civixero_Page_XeroErrorLogs extends CRM_Core_Page {
                 "return"      => array("contact_id.display_name","accounts_contact_id","error_data","last_sync_date","contact_id"),
                 "options"     => array('limit' => $limit, 'offset' => $offset, 'sort' => 'id DESC'),
             ));
-    
+
             $accountcontacts = $accountcontacts["values"];
             $this->formatErrors($accountcontacts);
             $this->formatContactsInfo($accountcontacts);

--- a/Civixero.civix.php
+++ b/Civixero.civix.php
@@ -3,6 +3,76 @@
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_Civixero_ExtensionUtil {
+  const SHORT_NAME = "Civixero";
+  const LONG_NAME = "nz.co.fuzion.civixero";
+  const CLASS_PREFIX = "CRM_Civixero";
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = array()) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = array(self::LONG_NAME, NULL);
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($path === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_Civixero_ExtensionUtil as E;
+
+/**
  * (Delegated) Implements hook_civicrm_config().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
@@ -190,7 +260,7 @@ function _Civixero_civix_civicrm_managed(&$entities) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
-        $e['module'] = 'nz.co.fuzion.civixero';
+        $e['module'] = E::LONG_NAME;
       }
       $entities[] = $e;
       if (empty($e['params']['version'])) {
@@ -222,7 +292,7 @@ function _Civixero_civix_civicrm_caseTypes(&$caseTypes) {
       // throw new CRM_Core_Exception($errorMessage);
     }
     $caseTypes[$name] = array(
-      'module' => 'nz.co.fuzion.civixero',
+      'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
     );
@@ -248,7 +318,7 @@ function _Civixero_civix_civicrm_angularModules(&$angularModules) {
     $name = preg_replace(':\.ang\.php$:', '', basename($file));
     $module = include $file;
     if (empty($module['ext'])) {
-      $module['ext'] = 'nz.co.fuzion.civixero';
+      $module['ext'] = E::LONG_NAME;
     }
     $angularModules[$name] = $module;
   }

--- a/Civixero.php
+++ b/Civixero.php
@@ -179,14 +179,54 @@ function civixero_civicrm_navigationMenu(&$menu) {
           'url' => 'civicrm/xero/settings',
           'permission' => 'administer CiviCRM',
           'operator' => NULL,
-          'separator' => 1,
+          'separator' => 0,
           'active' => 1,
           'parentID' => $navId,
           'navID' => $navId + 1,
         ),
       ),
 
-      $navId+2 => array (
+        $navId + 2 => array(
+            'attributes' => array(
+                'label' => 'Xero Error Logs',
+                'name' => 'Xero Error Logs',
+                'url' => NULL,
+                'permission' => 'administer CiviCRM',
+                'operator' => NULL,
+                'separator' => 1,
+                'active' => 1,
+                'parentID' => $navId,
+                'navID' => $navId + 2,
+            ),
+            'child' => array(
+                $navId+4 => array (
+                  'attributes' => array(
+                    'label' => 'Contact Errors',
+                    'name' => 'Contact Errors',
+                    'url' => 'civicrm/xero/errorlog',
+                    'permission' => 'administer CiviCRM',
+                    'operator' => null,
+                    'separator' => 0,
+                    'active' => 1,
+                    'parentID'   => $navId + 2,
+                  )
+                ),
+                $navId+5 => array (
+                  'attributes' => array(
+                    'label' => 'Invoice Errors',
+                    'name' => 'Invoice Errors',
+                    'url' => 'civicrm/xero/errorlog?for=invoice',
+                    'permission' => 'administer CiviCRM',
+                    'operator' => null,
+                    'separator' => 0,
+                    'active' => 1,
+                    'parentID'   => $navId + 5,
+                  )
+                ),
+            ),
+        ),
+
+      $navId+3 => array (
         'attributes' => array(
           'label' => 'Synchronize contacts',
           'name' => 'Contact Sync',
@@ -195,7 +235,7 @@ function civixero_civicrm_navigationMenu(&$menu) {
           'operator' => null,
           'separator' => 1,
           'active' => 1,
-          'parentID'   => $navId,
+          'parentID'   => $navId + 3,
         ))
 
     ),
@@ -206,6 +246,52 @@ function civixero_civicrm_navigationMenu(&$menu) {
   else {
     $menu[$navId] = $navigationMenu;
   }
+}
+
+/**
+ * Gettings contributions of sinlge contact
+ *
+ * @param $contactid
+ */
+function getContactContributions($contactid) {
+    $contributions = civicrm_api3("Contribution","get",array(
+        "contact_id" => $contactid,
+        "return"     => array("contribution_id"),
+        "sequential" => TRUE
+    ));
+    $contributions = array_column($contributions["values"], "id");
+    return $contributions;
+}
+
+/**
+ * Gettings errored invoices of given contributions
+ *
+ * @param $contributions
+ */
+function getErroredInvoicesOfContributions($contributions) {
+    $invoices = civicrm_api3("AccountInvoice","get",array(
+        "plugin"          => "xero",
+        "sequential"      => TRUE,
+        "contribution_id" => array("IN" => $contributions),
+        "error_data"      => array("<>" => "")
+    ));
+    return $invoices;
+}
+
+function _civixero_append_sync_errors(&$xeroBlock, $account_contact) {
+    if(empty($account_contact['accounts_needs_update']) && !empty($account_contact["error_data"])) {
+        $xeroBlock .= "<p class='xeroerror'> Contact <span class='error'>sync error</span> with Xero <a href='#' class='helpicon error xeroerror-info' data-xeroerrorid='".$account_contact["id"]."'></a></p>";
+    }
+
+    if (!empty($account_contact['accounts_contact_id'])) {
+        $contributions = getContactContributions($account_contact["contact_id"]);
+        if(count($contributions)) {
+            $invoices = getErroredInvoicesOfContributions($contributions);
+            if($invoices["count"]) {
+                $xeroBlock .= "<p class='xeroerror second'> ".$invoices["count"]." Contribution".(($invoices["count"] > 1)? 's' : '')." <span class='error'>not synced</span> with Xero <a href='#' class='helpicon error xeroerror-invoice-info' data-xeroerrorid='".$account_contact["contact_id"]."'></a></p>";
+            }
+        }
+    }
 }
 
 /**
@@ -227,7 +313,7 @@ function civixero_civicrm_pageRun(&$page) {
     try{
       $account_contacts = civicrm_api3('account_contact', 'get', array(
         'contact_id' => $contactID,
-        'return' => 'accounts_contact_id, accounts_needs_update, connector_id',
+        'return' => 'accounts_contact_id, accounts_needs_update, connector_id, error_data, id, contact_id',
         'plugin' => 'xero',
         'connector_id' => array('IN' => array_keys($connectors)),
       ));
@@ -238,11 +324,15 @@ function civixero_civicrm_pageRun(&$page) {
       foreach ($account_contacts['values'] as $account_contact) {
         $prefix = _civixero_get_connector_prefix($account_contact['connector_id']);
         if (!empty($account_contact['accounts_contact_id'])) {
-          $xeroBlock .= _civixero_get_xero_links_block($account_contact['accounts_contact_id'], $prefix);
+          $xeroBlock .= _civixero_get_xero_links_block($account_contact, $prefix);
         }
         elseif (!empty($account_contact['accounts_needs_update'])) {
           $xeroBlock .= _civicrm_get_xero_block_header();
           $xeroBlock .= "<p> Contact is queued for sync with Xero</p></div>";
+        } elseif(!empty($account_contact["error_data"])) {
+            $xeroBlock .= _civicrm_get_xero_block_header();
+            _civixero_append_sync_errors($xeroBlock, $account_contact);
+            $xeroBlock .= "</div>";
         }
       }
     }
@@ -283,6 +373,9 @@ function civixero_civicrm_pageRun(&$page) {
     'markup' => $xeroBlock,
     'type' => 'markup',
   ));
+
+  CRM_Core_Resources::singleton()->addStyleFile('nz.co.fuzion.civixero','css/civixero_styles.css');
+  CRM_Core_Resources::singleton()->addScriptFile('nz.co.fuzion.civixero','js/civixero_errors.js');
 
   //https://go.xero.com/AccountsReceivable/View.aspx?InvoiceID=
 }
@@ -326,7 +419,8 @@ function _civixero_get_connectors() {
  *
  * @return string
  */
-function _civixero_get_xero_links_block($xeroID, $connector_name) {
+function _civixero_get_xero_links_block($account_contact, $connector_name) {
+  $xeroID = $account_contact['accounts_contact_id'];
   $xeroLinks = array(
     'view_transactions' => array(
       'link' => 'https://go.xero.com/Reports/report.aspx?reportId=be392447-762b-444d-9cde-87c6bd185d00&report=TransactionsByContact&invoiceType=INVOICETYPE%2fACCREC&addToReportId=cf6fedeb-2188-493c-96e2-b862198f9b46&addToReportTitle=Income+by+Contact&reportClass=TransactionsByContact&contact=',
@@ -342,7 +436,7 @@ function _civixero_get_xero_links_block($xeroID, $connector_name) {
   foreach ($xeroLinks as $link) {
     $xeroBlock .= "<div class='crm-content'><a href='{$link['link']}{$xeroID}'>{$link['link_label']}</a></div>";
   }
-
+  _civixero_append_sync_errors($xeroBlock, $account_contact);
   $xeroBlock .= "</div>";
   return $xeroBlock;
 }

--- a/css/civixero_styles.css
+++ b/css/civixero_styles.css
@@ -1,0 +1,12 @@
+.crm-container a.helpicon.error {
+    color: #8c2e0b;
+}
+.xeroerror {
+    margin: 1.2em 0 1.2em 0;
+    text-align: center;
+}
+ul.syncErrorsList {
+    margin: 0;
+    padding: 0;
+    padding-left: 15px;
+}

--- a/js/civixero_errors.js
+++ b/js/civixero_errors.js
@@ -1,0 +1,37 @@
+CRM.$(function($) {
+    $('body').on('click','.xeroerror-info',function(e){
+        e.preventDefault();
+
+        $.getJSON(CRM.url("civicrm/ajax/civixero/sync/contact/errors",
+            {xeroerrorid: $(this).data('xeroerrorid')})
+        ).done(function (result) {
+            if(result.length > 0) {
+                CRM.alert(getErrorsText(result),"Contact sync","error");
+            }
+        });
+    });
+
+    $('body').on('click','.xeroerror-invoice-info',function(e){
+        e.preventDefault();
+
+        $.getJSON(CRM.url("civicrm/ajax/civixero/sync/invoice/errors",
+            {xeroerrorid: $(this).data('xeroerrorid')})
+        ).done(function (result) {
+            if(result.length > 0) {
+                CRM.alert(getErrorsText(result),"Contributions sync","error");
+            }
+        });
+    });
+
+    function getErrorsText(result) {
+        var text ="";
+        for(var i=0; i<result.length; i++) {
+            text += "<br>";
+            text += result[i];
+            if(i != (result.length-1)) {
+                text += "<br>";
+            }
+        }
+        return text;
+    }
+});

--- a/templates/CRM/Civixero/Page/XeroErrorLogs.tpl
+++ b/templates/CRM/Civixero/Page/XeroErrorLogs.tpl
@@ -1,0 +1,60 @@
+<div class="crm-content-block crm-block">
+    {include file="CRM/common/pager.tpl" location="top"}
+    {include file='CRM/common/jsortable.tpl'}
+    <div id="claim_level-wrapper" class="dataTables_wrapper">
+        <table id="claim_level-table" class="display">
+            <thead>
+            <tr>
+                <th>ID</th>
+                {if $errorsfor == 'contact'}
+                    <th id="nosort">{ts}Contact{/ts}</th>
+                    <th id="nosort">{ts}Account Contact Id{/ts}</th>
+                {else}
+                    <th id="nosort" width="100">{ts}Contribution{/ts}</th>
+                    <th id="nosort">{ts}Account Invoice Id{/ts}</th>
+                {/if}
+                <th id="nosort">{ts}Error Data{/ts}</th>
+                <th>{ts}Last Sync Date{/ts}</th>
+            </tr>
+            </thead>
+            <tbody>
+            {assign var="rowClass" value="odd-row"}
+            {assign var="rowCount" value=0}
+            {foreach from=$syncErrors key=errorId item=syncerror}
+                {assign var="rowCount" value=$rowCount+1}
+                <tr id="row{$rowCount}" class="{cycle values="odd,even"}">
+                    <td>{ $syncerror.id }</td>
+                    {if $errorsfor == 'contact'}
+                        <td>
+                            <a href="{crmURL p='civicrm/contact/view' q="action=view&reset=1&cid=`$syncerror.contact_id`"}" target="_blank">{ $syncerror.contactname }</a>
+                        </td>
+                        <td>{ $syncerror.accounts_contact_id }</td>
+                    {else}
+                        <td>
+                            <a href="{crmURL p='civicrm/contact/view/contribution' q="action=view&reset=1&id=`$syncerror.contribution_id`"}" target="_blank">#{ $syncerror.contribution_id }</a><br>
+                            From: <a href="{crmURL p='civicrm/contact/view' q="action=view&reset=1&cid=`$syncerror.contact_id`"}" target="_blank">{ $syncerror.contactname }</a>
+                        </td>
+                        <td>{ $syncerror.accounts_invoice_id }</td>
+                    {/if}
+                    <td>
+                        <ul class="syncErrorsList">
+                            {foreach from=$syncerror.error_data key=eid item=error}
+                                <li>{ $error }</li>
+                            {/foreach}
+                        </ul>
+                    </td>
+
+                    <td>{ $syncerror.last_sync_date|crmDate }
+                    </td>
+                </tr>
+                {if $rowClass eq "odd-row"}
+                    {assign var="rowClass" value="even-row"}
+                {else}
+                    {assign var="rowClass" value="odd-row"}
+                {/if}
+            {/foreach}
+            </tbody>
+        </table>
+    </div>
+    {include file="CRM/common/pager.tpl" location="bottom"}
+</div>

--- a/xml/Menu/Civixero.xml
+++ b/xml/Menu/Civixero.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<menu>
+  <item>
+    <path>civicrm/ajax/civixero/sync/contact/errors</path>
+    <page_callback>CRM_Civixero_Page_AJAX::contactSyncErrors</page_callback>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/ajax/civixero/sync/invoice/errors</path>
+    <page_callback>CRM_Civixero_Page_AJAX::invoiceSyncErrors</page_callback>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/xero/errorlog</path>
+    <page_callback>CRM_Civixero_Page_XeroErrorLogs</page_callback>
+    <title>XeroErrorLogs</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+</menu>

--- a/xml/Menu/Civixero.xml
+++ b/xml/Menu/Civixero.xml
@@ -3,17 +3,17 @@
   <item>
     <path>civicrm/ajax/civixero/sync/contact/errors</path>
     <page_callback>CRM_Civixero_Page_AJAX::contactSyncErrors</page_callback>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>access CiviContribute</access_arguments>
   </item>
   <item>
     <path>civicrm/ajax/civixero/sync/invoice/errors</path>
     <page_callback>CRM_Civixero_Page_AJAX::invoiceSyncErrors</page_callback>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>access CiviContribute</access_arguments>
   </item>
   <item>
     <path>civicrm/xero/errorlog</path>
     <page_callback>CRM_Civixero_Page_XeroErrorLogs</page_callback>
     <title>XeroErrorLogs</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>access CiviContribute</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
Exposing the Account Sync error logs in the CiviCRM UI so that error messages in civicrm_account_contact and civicrm_account_invoice can be reviewed.

## Implementation
1. Showing (?) icon on view contact page clicking on it opens CiviCRM error popup which displays the error message.
2. Displaying all the errors on single page, we have created two new pages under Xero menu which shows all error logs from Contacts and Invoices table.