### PR TITLE
Fix contact push case where AccountContact record has NULL contact_id

### DIFF
--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -128,7 +128,6 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
             /* When Xero returns an ID that matches an existing account_contact, update it instead. */
             $matching = civicrm_api('account_contact', 'getsingle', array(
                 'accounts_contact_id' => $result['Contacts']['Contact']['ContactID'],
-                'contact_id' => array('!=' => $record['contact_id']),
                 'plugin' => $this->_plugin,
                 'version' => 3,
               )
@@ -141,8 +140,8 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
                 $record['do_not_sync'] = 0;
                 $record['id'] = $matching['id'];
               }
-              else {
-                throw new CiviCRM_API3_Exception(ts('Attempt to sync Contact %1 to Xero entry for existing Contact %2. ', array(1 => $record['contact_id'], 2 => $matching['contact_id']), NULL, $record));
+              elseif($matching['contact_id'] != $record['contact_id']) {
+                throw new CiviCRM_API3_Exception(ts('Attempt to sync Contact %1 to Xero entry for existing Contact %2. ', array(1 => $record['contact_id'], 2 => $matching['contact_id']), NULL, $record), 'xero_dup_contact');
               }
             }
 


### PR DESCRIPTION
(Agileware ref. CIVIXERO-21)

Otherwise it stumbles over `NULL != $record['contact_id']`.
Also fixes a fatal ArgumentCountError when throwing an exception
where a contact_id is found, but refers to a different Contact.