### PR TITLE
Added contact/invoice blocks as region blocks and defined them in contactSummaryBlocks hook.

### DIFF
--- a/CRM/Civixero/Page/Inline/ContactSyncErrors.php
+++ b/CRM/Civixero/Page/Inline/ContactSyncErrors.php
@@ -1,0 +1,47 @@
+<?php
+
+class CRM_Civixero_Page_Inline_ContactSyncErrors extends CRM_Core_Page {
+
+  public function run() {
+    $contactId = CRM_Utils_Request::retrieveValue('cid', 'Positive');
+    if (!$contactId) {
+      return;
+    }
+    self::addContactSyncErrorsBlock($this, $contactId);
+    parent::run();
+  }
+
+  /**
+   * @param CRM_Core_Page $page
+   * @param int $contactID
+   */
+  public static function addContactSyncErrorsBlock(&$page, $contactID) {
+
+    $hasContactErrors = FALSE;
+
+    try{
+      $connectors = _civixero_get_connectors();
+      $account_contact = civicrm_api3('account_contact', 'getsingle', array(
+        'contact_id' => $contactID,
+        'return' => 'accounts_contact_id, accounts_needs_update, connector_id, error_data, id, contact_id',
+        'plugin' => 'xero',
+        'connector_id' => array('IN' => array_keys($connectors)),
+      ));
+
+      $page->assign('accountContactId_xero', $account_contact['id']);
+
+      if (!empty($account_contact["error_data"])) {
+        $hasContactErrors = TRUE;
+      }
+
+    }
+    catch(Exception $e) {
+
+    }
+
+    $page->assign('hasContactErrors_xero', $hasContactErrors);
+    $page->assign('contactID_xero', $contactID);
+
+  }
+
+}

--- a/CRM/Civixero/Page/Inline/ContactSyncLink.php
+++ b/CRM/Civixero/Page/Inline/ContactSyncLink.php
@@ -1,0 +1,46 @@
+<?php
+
+class CRM_Civixero_Page_Inline_ContactSyncLink extends CRM_Core_Page {
+
+  public function run() {
+    $contactId = CRM_Utils_Request::retrieveValue('cid', 'Positive');
+    if (!$contactId) {
+      return;
+    }
+    self::addContactSyncLinkBlock($this, $contactId);
+    parent::run();
+  }
+
+  /**
+   * @param CRM_Core_Page $page
+   * @param int $contactID
+   */
+  public static function addContactSyncLinkBlock(&$page, $contactID) {
+
+    $isContactSynced = 0;
+
+    try{
+      $connectors = _civixero_get_connectors();
+      $account_contact = civicrm_api3('account_contact', 'getsingle', array(
+        'contact_id' => $contactID,
+        'return' => 'accounts_contact_id, accounts_needs_update, connector_id, error_data, id, contact_id',
+        'plugin' => 'xero',
+        'connector_id' => array('IN' => array_keys($connectors)),
+      ));
+
+      if (!empty($account_contact['accounts_contact_id'])) {
+        $isContactSynced = TRUE;
+        $page->assign('accountContactId_xero', $account_contact['accounts_contact_id']);
+      }
+
+    }
+    catch(Exception $e) {
+
+    }
+
+    $page->assign('isContactSynced_xero', $isContactSynced);
+    $page->assign('contactID_xero', $contactID);
+
+  }
+
+}

--- a/CRM/Civixero/Page/Inline/ContactSyncStatus.php
+++ b/CRM/Civixero/Page/Inline/ContactSyncStatus.php
@@ -1,0 +1,48 @@
+<?php
+
+class CRM_Civixero_Page_Inline_ContactSyncStatus extends CRM_Core_Page {
+
+  public function run() {
+    $contactId = CRM_Utils_Request::retrieveValue('cid', 'Positive');
+    if (!$contactId) {
+      return;
+    }
+    self::addContactSyncStatusBlock($this, $contactId);
+    parent::run();
+  }
+
+  /**
+   * @param CRM_Core_Page $page
+   * @param int $contactID
+   */
+  public static function addContactSyncStatusBlock(&$page, $contactID) {
+
+    $syncStatus = 0;
+
+    try{
+      $connectors = _civixero_get_connectors();
+      $account_contact = civicrm_api3('account_contact', 'getsingle', array(
+        'contact_id' => $contactID,
+        'return' => 'accounts_contact_id, accounts_needs_update, connector_id, error_data, id, contact_id',
+        'plugin' => 'xero',
+        'connector_id' => array('IN' => array_keys($connectors)),
+      ));
+
+      if (!empty($account_contact['accounts_contact_id'])) {
+        $syncStatus = 1;
+      }
+      elseif (!empty($account_contact['accounts_needs_update'])) {
+        $syncStatus = 2;
+      }
+
+    }
+    catch(Exception $e) {
+
+    }
+
+    $page->assign('syncStatus_xero', $syncStatus);
+    $page->assign('contactID_xero', $contactID);
+
+  }
+
+}

--- a/CRM/Civixero/Page/Inline/InvoiceSyncErrors.php
+++ b/CRM/Civixero/Page/Inline/InvoiceSyncErrors.php
@@ -1,0 +1,52 @@
+<?php
+
+class CRM_Civixero_Page_Inline_InvoiceSyncErrors extends CRM_Core_Page {
+
+  public function run() {
+    $contactId = CRM_Utils_Request::retrieveValue('cid', 'Positive');
+    if (!$contactId) {
+      return;
+    }
+    self::addInvoiceSyncErrorsBlock($this, $contactId);
+    parent::run();
+  }
+
+  /**
+   * @param CRM_Core_Page $page
+   * @param int $contactID
+   */
+  public static function addInvoiceSyncErrorsBlock(&$page, $contactID) {
+
+    $hasInvoiceErrors = FALSE;
+
+    try{
+      $connectors = _civixero_get_connectors();
+      $account_contact = civicrm_api3('account_contact', 'getsingle', array(
+        'contact_id' => $contactID,
+        'return' => 'accounts_contact_id, accounts_needs_update, connector_id, error_data, id, contact_id',
+        'plugin' => 'xero',
+        'connector_id' => array('IN' => array_keys($connectors)),
+      ));
+
+      $page->assign('accountContactId_xero', $account_contact['id']);
+
+      $contributions = getContactContributions($account_contact["contact_id"]);
+      if (count($contributions)) {
+        $invoices = getErroredInvoicesOfContributions($contributions);
+        if ($invoices["count"]) {
+          $hasInvoiceErrors = TRUE;
+          $page->assign('erroredInvoices_xero', $invoices["count"]);
+        }
+      }
+
+    }
+    catch(Exception $e) {
+
+    }
+
+    $page->assign('hasInvoiceErrors_xero', $hasInvoiceErrors);
+    $page->assign('contactID_xero', $contactID);
+
+  }
+
+}

--- a/CRM/Civixero/Page/Inline/InvoiceSyncLink.php
+++ b/CRM/Civixero/Page/Inline/InvoiceSyncLink.php
@@ -1,0 +1,46 @@
+<?php
+
+class CRM_Civixero_Page_Inline_InvoiceSyncLink extends CRM_Core_Page {
+
+  public function run() {
+    $contactId = CRM_Utils_Request::retrieveValue('cid', 'Positive');
+    if (!$contactId) {
+      return;
+    }
+    self::addInvoiceSyncLinkBlock($this, $contactId);
+    parent::run();
+  }
+
+  /**
+   * @param CRM_Core_Page $page
+   * @param int $contactID
+   */
+  public static function addInvoiceSyncLinkBlock(&$page, $contactID) {
+
+    $isContactSynced = 0;
+
+    try{
+      $connectors = _civixero_get_connectors();
+      $account_contact = civicrm_api3('account_contact', 'getsingle', array(
+        'contact_id' => $contactID,
+        'return' => 'accounts_contact_id, accounts_needs_update, connector_id, error_data, id, contact_id',
+        'plugin' => 'xero',
+        'connector_id' => array('IN' => array_keys($connectors)),
+      ));
+
+      if (!empty($account_contact['accounts_contact_id'])) {
+        $isContactSynced = TRUE;
+        $page->assign('accountContactId_xero', $account_contact['accounts_contact_id']);
+      }
+
+    }
+    catch(Exception $e) {
+
+    }
+
+    $page->assign('isContactSynced_xero', $isContactSynced);
+    $page->assign('contactID_xero', $contactID);
+
+  }
+
+}

--- a/templates/CRM/Civixero/ContactSyncBlock.tpl
+++ b/templates/CRM/Civixero/ContactSyncBlock.tpl
@@ -1,0 +1,7 @@
+<div class="crm-summary-basic-block crm-clear crm-summary-block">
+    {include file="CRM/Civixero/Page/Inline/ContactSyncStatus.tpl"}
+    {include file="CRM/Civixero/Page/Inline/ContactSyncLink.tpl"}
+    {include file="CRM/Civixero/Page/Inline/InvoiceSyncLink.tpl"}
+    {include file="CRM/Civixero/Page/Inline/ContactSyncErrors.tpl"}
+    {include file="CRM/Civixero/Page/Inline/InvoiceSyncErrors.tpl"}
+</div>

--- a/templates/CRM/Civixero/Page/Inline/ContactSyncErrors.tpl
+++ b/templates/CRM/Civixero/Page/Inline/ContactSyncErrors.tpl
@@ -1,0 +1,10 @@
+{if $hasContactErrors_xero}
+    <div class="crm-summary-row">
+        <div class="crm-label">
+            Contact Sync Errors with Xero
+        </div>
+        <div class="crm-content">
+            Contact <span class='error'>sync error</span> with Xero <a href='#' class='helpicon error xeroerror-info' data-xeroerrorid='{$accountContactId_xero}'></a>
+        </div>
+    </div>
+{/if}

--- a/templates/CRM/Civixero/Page/Inline/ContactSyncLink.tpl
+++ b/templates/CRM/Civixero/Page/Inline/ContactSyncLink.tpl
@@ -1,0 +1,7 @@
+{if $isContactSynced_xero}
+    <div class="crm-summary-row">
+        <div class="crm-content">
+            <a href="https://go.xero.com/Contacts/View.aspx?contactID={$accountContactId_xero}">Xero Contact</a>
+        </div>
+    </div>
+{/if}

--- a/templates/CRM/Civixero/Page/Inline/ContactSyncStatus.tpl
+++ b/templates/CRM/Civixero/Page/Inline/ContactSyncStatus.tpl
@@ -1,0 +1,32 @@
+{if $syncStatus_xero!= 1}
+    <div class="crm-summary-row">
+        <div class="crm-label">
+            Xero Sync Status
+        </div>
+        <div class="crm-content">
+            {if $syncStatus_xero == 0}
+                <a href='#' id='xero-sync' data-contact-id={$contactID_xero}>Queue Sync to Xero</a>
+            {elseif $syncStatus_xero == 1}
+                Contact is synced with Xero
+            {elseif $syncStatus_xero == 2}
+                Contact is queued for sync with Xero
+            {/if}
+        </div>
+
+        {literal}
+
+            <script type="text/javascript">
+                cj('#xero-sync').click(function( event) {
+                    event.preventDefault();
+                    CRM.api('account_contact', 'create',{
+                        'contact_id' : cj(this).data('contact-id'),
+                        'plugin' : 'xero',
+                        'accounts_needs_update' : 1,
+                    });
+                    cj(this).replaceWith('Contact is queued for sync with Xero');
+                });
+            </script>
+
+        {/literal}
+    </div>
+{/if}

--- a/templates/CRM/Civixero/Page/Inline/InvoiceSyncErrors.tpl
+++ b/templates/CRM/Civixero/Page/Inline/InvoiceSyncErrors.tpl
@@ -1,0 +1,10 @@
+{if $hasInvoiceErrors_xero}
+    <div class="crm-summary-row">
+        <div class="crm-label">
+            Invoice Sync Errors with Xero
+        </div>
+        <div class="crm-content">
+            {$erroredInvoices_xero} Contribution <span class='error'>not synced</span> with Xero <a href='#' class='helpicon error xeroerror-invoice-info' data-xeroerrorid='{$contactID_xero}'></a>
+        </div>
+    </div>
+{/if}

--- a/templates/CRM/Civixero/Page/Inline/InvoiceSyncLink.tpl
+++ b/templates/CRM/Civixero/Page/Inline/InvoiceSyncLink.tpl
@@ -1,0 +1,7 @@
+{if $isContactSynced_xero}
+    <div class="crm-summary-row">
+        <div class="crm-content">
+            <a href="https://go.xero.com/Reports/report.aspx?reportId=be392447-762b-444d-9cde-87c6bd185d00&report=TransactionsByContact&invoiceType=INVOICETYPE%2fACCREC&addToReportId=cf6fedeb-2188-493c-96e2-b862198f9b46&addToReportTitle=Income+by+Contact&reportClass=TransactionsByContact&contact={$accountContactId_xero}">Xero Transactions</a>
+        </div>
+    </div>
+{/if}


### PR DESCRIPTION
This PR implements the new CiviCRM Blocks for CiviXero. Implements Contact sync status, Invoice sync errors, Contact sync errors, Contact Sync link, Invoice sync link blocks.

CiviCRM Blocks are then available in the CiviCRM Contact Summary Layout Editor, https://github.com/civicrm/org.civicrm.contactlayout

This PR removes the page_run_hook function which previously added links on the Contact Summary screen for the Xero Contact because this has been replaced by the CiviCRM Blocks method of adding the links.

_Agileware Ref: CIVIXERO-18_
