### PR TITLE
Fix url for contacts error log page

### DIFF
--- a/CRM/Civixero/Page/XeroErrorLogs.php
+++ b/CRM/Civixero/Page/XeroErrorLogs.php
@@ -56,6 +56,7 @@ class CRM_Civixero_Page_XeroErrorLogs extends CRM_Core_Page {
             $accountcontacts = $accountcontacts["values"];
             $this->formatErrors($accountcontacts);
             $this->formatContactsInfo($accountcontacts);
+            $this->formatUrl($accountcontacts);
             return $accountcontacts;
         }
 


### PR DESCRIPTION
Overview
------
Missing part for #57 

Before
------
No URL on contact error log page.

After
------
Correct URL on contact error log page.

Comment
------


Agileware ref: CIVIXERO-30