### PR TITLE
Skip cleared invoice error when pushing

### DIFF
--- a/CRM/Civixero/Page/AJAX.php
+++ b/CRM/Civixero/Page/AJAX.php
@@ -130,6 +130,7 @@ class CRM_Civixero_Page_AJAX extends CRM_Core_Page {
             $errordata = json_decode($errordata, TRUE);
             $errordata["error_cleared"] = 1;
             $accountinvoice["error_data"] = json_encode($errordata);
+            $accountinvoice["accounts_needs_update"] = 0;
             civicrm_api3("AccountInvoice","create",$accountinvoice);
         }
         CRM_Utils_JSON::output(array(


### PR DESCRIPTION
Overview
------
Clearing the error on invoice error log page does not mark the error to be skipped by the push job. So the error shows up again after the scheduled job executed.

Before
------
The error pops up again.

After
------
The error does not pop up again.

Comment
------


Agileware ref: CIVIXERO-32