### PR TITLE
Don't append contact number to display name when creating in Xero

### DIFF
--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -186,7 +186,7 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
    */
   protected function mapToAccounts($contact, $accountsID) {
     $new_contact = array(
-      "Name" => $contact['display_name'] . " - " . $contact['contact_id'],
+      "Name" => $contact['display_name'],
       "FirstName" => $contact['first_name'],
       "LastName" => $contact['last_name'],
       "EmailAddress" => CRM_Utils_Rule::email($contact['email']) ? $contact['email'] : '',


### PR DESCRIPTION
 As this appears on invoices and we already have it in the 'Contact Code' field.

@eileenmcnaughton I don't know if it was intended this way but you end up with contacts in Xero like "Joe Bloggs - 29" and that filters through onto invoices which looks a bit odd.  We already have the contact ID showing as "Contact Code" on Xero.