### PR TITLE
Further fix for IDs on sync blocks

### DIFF
--- a/CRM/Civixero/Page/Inline/ContactSyncErrors.php
+++ b/CRM/Civixero/Page/Inline/ContactSyncErrors.php
@@ -16,7 +16,6 @@ class CRM_Civixero_Page_Inline_ContactSyncErrors extends CRM_Core_Page {
    * @param int $contactID
    */
   public static function addContactSyncErrorsBlock(&$page, $contactID) {
-
     $hasContactErrors = FALSE;
 
     try{
@@ -27,8 +26,6 @@ class CRM_Civixero_Page_Inline_ContactSyncErrors extends CRM_Core_Page {
         'plugin' => 'xero',
         'connector_id' => array('IN' => array_keys($connectors)),
       ));
-
-      $page->assign('accountContactId_xero', $account_contact['accounts_contact_id']);
 
       if (!empty($account_contact["error_data"])) {
         $hasContactErrors = TRUE;

--- a/CRM/Civixero/Page/Inline/InvoiceSyncErrors.php
+++ b/CRM/Civixero/Page/Inline/InvoiceSyncErrors.php
@@ -28,8 +28,6 @@ class CRM_Civixero_Page_Inline_InvoiceSyncErrors extends CRM_Core_Page {
         'connector_id' => array('IN' => array_keys($connectors)),
       ));
 
-      $page->assign('accountContactId_xero', $account_contact['accounts_contact_id']);
-
       $contributions = getContactContributions($account_contact["contact_id"]);
       if (count($contributions)) {
         $invoices = getErroredInvoicesOfContributions($contributions);

--- a/templates/CRM/Civixero/Page/Inline/ContactSyncErrors.tpl
+++ b/templates/CRM/Civixero/Page/Inline/ContactSyncErrors.tpl
@@ -4,7 +4,8 @@
             Contact Sync Errors with Xero
         </div>
         <div class="crm-content">
-            Contact <span class='error'>sync error</span> with Xero <a href='#' class='helpicon error xeroerror-info' data-xeroerrorid='{$accountContactId_xero}'></a>
+          Contact <span class='error'>sync error</span> with Xero
+          <a href='#' class='helpicon error xeroerror-info' data-xeroerrorid='{$contactID_xero}'></a>
         </div>
     </div>
 {/if}

--- a/templates/CRM/Civixero/Page/Inline/InvoiceSyncErrors.tpl
+++ b/templates/CRM/Civixero/Page/Inline/InvoiceSyncErrors.tpl
@@ -4,7 +4,8 @@
             Invoice Sync Errors with Xero
         </div>
         <div class="crm-content">
-            {$erroredInvoices_xero} Contribution <span class='error'>not synced</span> with Xero <a href='#' class='helpicon error xeroerror-invoice-info' data-xeroerrorid='{$contactID_xero}'></a>
+          {$erroredInvoices_xero} Contribution <span class='error'>not synced</span> with Xero
+          <a href='#' class='helpicon error xeroerror-invoice-info' data-xeroerrorid='{$contactID_xero}'></a>
         </div>
     </div>
 {/if}


### PR DESCRIPTION
Looks like the original code did a bit too much copy/paste and introduced errors in the IDs for the links