### PR TITLE
CIVIXERO-40: Fix tax_amount test to account for string '0.00'

### DIFF
--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -189,7 +189,10 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
       );
       $total_amount += $lineItem['qty'] * $lineItem['unit_price'];
 
-      if(!empty($lineItem['tax_amount'])) {
+      // Historically 'tax_amount' might come at us as NULL, the empty string,
+      // or a false numeric, but now it seems to be a string. '0.00' casts to
+      // true but is equal to zero, so we have to check it.
+      if(isset($lineItem['tax_amount']) && $lineItem['tax_amount'] && $lineItem['tax_amount'] !== '0.00') {
         // If we discover a non-zero tax_amount, switch to tax exclusive amounts.
         $line_amount_types = 'Exclusive';
       }


### PR DESCRIPTION
Recent change to **something** in CiviCRM meant that we now see stuff with no tax account come in with the string '0.00' instead of an actual float value.

This updates the logic for setting the line item types to take that into account.

Main application for this is where organisations have Tax & Invoicing enabled, and have tax configured in Xero (e.g. GST), but have no tax accounts or calculation in CiviCRM.

Before
------

When the tax amounts are all zero, Invoices would be pushed to Xero accounts with tax applied as tax exclusive when they should be tax inclusive, causing Xero to add extra tax on top.

After
-----

Under the same circumstances, Invoices are pushed as tax inclusive, and do not get extra tax added by Xero.