### PR TITLE
Add parameter to Civixero.contactpull to pull a single contact

### DIFF
--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -13,9 +13,11 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
    * @throws CRM_Core_Exception
    */
   public function pull($params) {
+    // If we specify a xero contact id (UUID) then we try to load ONLY that contact.
+    isset($params['xero_contact_id']) ?: $params['xero_contact_id'] = FALSE;
     try {
       $result = $this->getSingleton($params['connector_id'])
-        ->Contacts(FALSE, $this->formatDateForXero($params['start_date']));
+        ->Contacts($params['xero_contact_id'], $this->formatDateForXero($params['start_date']));
       if (!is_array($result)) {
         throw new API_Exception('Sync Failed', 'xero_retrieve_failure', (array) $result);
       }

--- a/api/v3/Civixero/Contactpull.php
+++ b/api/v3/Civixero/Contactpull.php
@@ -24,6 +24,12 @@ function _civicrm_api3_civixero_contactpull_spec(&$spec) {
     'title' => 'Connector ID',
     'description' => 'Connector ID if using nz.co.fuzion.connectors, else 0',
   );
+  $spec['xero_contact_id'] = [
+    'type' => CRM_Utils_Type::T_STRING,
+    'name' => 'xero_contact_id',
+    'title' => 'Xero Contact ID',
+    'description' => 'Specify Xero Contact UUID to retrieve a single contact record',
+  ];
 }
 
 /**


### PR DESCRIPTION
This allows you to "pull" a specific Xero contact record into CiviCRM using the API.