### PR TITLE
Push invoices from CiviCRM to Xero using actual currency instead of CiviCRM default

### DIFF
--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -221,7 +221,7 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
       "DueDate" => substr($invoiceData['receive_date'], 0, 10),
       "Status" => $status,
       "InvoiceNumber" => $prefix . $invoiceData['id'],
-      "CurrencyCode" => CRM_Core_Config::singleton()->defaultCurrency,
+      "CurrencyCode" => $invoiceData['currency'],
       "Reference" => $invoiceData['display_name'] . ' ' . $invoiceData['contribution_source'],
       "LineAmountTypes" => $line_amount_types,
       'LineItems' => ['LineItem' => $lineItems],

--- a/settings/Civixero.setting.php
+++ b/settings/Civixero.setting.php
@@ -1,9 +1,9 @@
 <?php
 
 $invoice_statuses = [
-  'SUBMITTED' => 'Submitted',
-  'AUTHORISED' => 'Authorised',
   'DRAFT' => 'Draft',
+  'SUBMITTED' => 'Submitted',
+  'AUTHORISED' => 'Approved',
 ];
 
 return [


### PR DESCRIPTION
For some reason we were passing the default currency of CiviCRM instead of the actual currency of the contribution.

Also clarify the invoice sync statuses in settings (so they are in sequential order and labelled as per Xero).