### PR TITLE
NULL connector_id when 'Queue Sync to Xero' clicked

### DIFF
--- a/templates/CRM/Civixero/Page/Inline/ContactSyncStatus.tpl
+++ b/templates/CRM/Civixero/Page/Inline/ContactSyncStatus.tpl
@@ -21,6 +21,7 @@
                     CRM.api('account_contact', 'create',{
                         'contact_id' : cj(this).data('contact-id'),
                         'plugin' : 'xero',
+                        'connector_id' : 0,
                         'accounts_needs_update' : 1,
                     });
                     cj(this).replaceWith('Contact is queued for sync with Xero');


### PR DESCRIPTION
If I click 'Queue Sync to Xero' an entry is created in the Accounts Contact table with connector_id NULL. The Contact Push job ignores this entry. Setting connector_id to zero works for me but may fail if there are multiple connectors.