### PR TITLE
Remove unhelpful log message and replace with one that could be useful

### DIFF
--- a/CRM/Civixero/OAuth2/Xero.php
+++ b/CRM/Civixero/OAuth2/Xero.php
@@ -26,12 +26,9 @@ class CRM_Civixero_OAuth2_Xero {
 
   private $resourceOwnerURL = 'https://api.xero.com/api.xro/2.0/Organisation';
 
-  private $connectionsURL = 'https://api.xero.com/connections';
-
   private $tenantID;
 
   private $redirectURL;
-
 
   /**
    * Get Xero instance.
@@ -117,8 +114,10 @@ class CRM_Civixero_OAuth2_Xero {
     // Try again if failed?
     if ($newToken) {
       $this->store->save($newToken);
-      CRM_Core_Error::debug_var('CiviXeroDebug', 'Storing renewed token.');
       return $newToken;
+    }
+    else {
+      \Civi::log()->warning('Xero renewToken failed - no new token.');
     }
   }
 


### PR DESCRIPTION
`[info] $CiviXeroDebug = Storing renewed token.` is added to the logs multiple times a day. It is not helpful because it fills the logs and does not tell us anything. This PR removes it and adds another one in the case that a new token is NOT obtained - which would be more useful if troubleshooting!

`$connectionsURL` is unused.