### PR TITLE
Allow you to push a single contact by CiviCRM contact ID using the API

### DIFF
--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -97,13 +97,18 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
    */
   public function push($params) {
     try {
-      $records = civicrm_api3('account_contact', 'get', [
-          'accounts_needs_update' => 1,
-          'plugin' => $this->_plugin,
-          'api.contact.get' => 1,
-          'connector_id' => $params['connector_id'],
-        ]
-      );
+      $accountContactParams = [
+        'accounts_needs_update' => 1,
+        'plugin' => $this->_plugin,
+        'api.contact.get' => 1,
+        'connector_id' => $params['connector_id'],
+      ];
+      // If we specified a CiviCRM contact ID just push that contact.
+      if (!empty($params['contact_id'])) {
+        $accountContactParams['contact_id'] = $params['contact_id'];
+        $accountContactParams['accounts_needs_update'] = 0;
+      }
+      $records = civicrm_api3('account_contact', 'get', $accountContactParams);
 
       $errors = [];
 

--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -144,8 +144,9 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
           if ($result === FALSE) {
             unset($record['accounts_modified_date']);
           }
-          elseif ($responseErrors) {
+          if ($responseErrors) {
             $record['error_data'] = json_encode($responseErrors);
+            throw new CRM_Core_Exception('Error in response from Xero');
           }
           else {
             /* When Xero returns an ID that matches an existing account_contact, update it instead. */
@@ -184,7 +185,7 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
           unset($record['last_sync_date']);
           civicrm_api3('account_contact', 'create', $record);
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (Exception $e) {
           $errors[] = ts('Failed to push ') . $record['contact_id'] . ' (' . $record['accounts_contact_id'] . ' )'
             . ts(' with error ') . $e->getMessage() . print_r($responseErrors, TRUE)
             . ts('Contact Push failed');

--- a/api/v3/Civixero/Contactpush.php
+++ b/api/v3/Civixero/Contactpush.php
@@ -24,6 +24,13 @@ function _civicrm_api3_civixero_contactpush_spec(&$spec) {
     'title' => 'Connector ID',
     'description' => 'Connector ID if using nz.co.fuzion.connectors, else 0',
   ];
+  $spec['contact_id'] = [
+    'name' => 'contact_id',
+    'title' => 'contact ID',
+    'description' => 'ID of the CiviCRM contact',
+    'api.required' => 0,
+    'type' => CRM_Utils_Type::T_INT,
+  ];
 }
 
 /**


### PR DESCRIPTION
Hopefully will be able to follow this up with a link in the UI to "push now" when it says "Contact is queued for sync with Xero". But this is useful by itself for debugging etc. because you can use the API directly to push a single contact.

Also fixed an issue with reporting an error response from Xero when pushing a contact