### PR TITLE
Fix pushing new contact

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -15,8 +15,8 @@
     <author>eileen</author>
     <email>eileen@fuzion.co.nz</email>
   </maintainer>
-  <releaseDate>2022-06-27</releaseDate>
-  <version>2.0.2</version>
+  <releaseDate>2022-08-09</releaseDate>
+  <version>2.0.3</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.49</ver>


### PR DESCRIPTION
Fix pushing a new contact.

@eileenmcnaughton See #94. 

You had to add api.contact.get = 1 back in because we were using `civicrm_api3('Contact', 'get'` which returns an array containing 'values'. I should either have changed that to getsingle, or to API4. I chose API4. Also note that we can probably simplify the Email get once we can use the new support for getting primary email in API4 Contact.get.