### PR TITLE
Fix display of sync status errors on contact summary

### DIFF
--- a/CRM/Civixero/Page/Inline/ContactSyncStatus.php
+++ b/CRM/Civixero/Page/Inline/ContactSyncStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Civixero_ExtensionUtil as E;
+
 class CRM_Civixero_Page_Inline_ContactSyncStatus extends CRM_Core_Page {
 
   public function run() {
@@ -36,7 +38,8 @@ class CRM_Civixero_Page_Inline_ContactSyncStatus extends CRM_Core_Page {
 
     }
     catch (Exception $e) {
-
+      \Civi::log(E::SHORT_NAME)->error('Error getting sync status for contactID: ' . $contactID . ': ' . $e->getMessage());
+      $syncStatus = 3;
     }
 
     $page->assign('syncStatus_xero', $syncStatus);

--- a/templates/CRM/Civixero/Page/Inline/ContactSyncStatus.tpl
+++ b/templates/CRM/Civixero/Page/Inline/ContactSyncStatus.tpl
@@ -1,31 +1,39 @@
-{if $syncStatus_xero!= 1}
-    <div class="crm-summary-row">
-        <div class="crm-label">
-            Xero Sync Status
-        </div>
-        <div class="crm-content">
-            {if $syncStatus_xero == 0}
-                <a href='#' id='xero-sync' data-contact-id={$contactID_xero}>Queue Sync to Xero</a>
-            {elseif $syncStatus_xero == 1}
-                Contact is synced with Xero
-            {elseif $syncStatus_xero == 2}
-                Contact is queued for sync with Xero
-            {/if}
-        </div>
+<div class="crm-summary-row">
+  <div class="crm-label">
+      {ts}Xero Sync Status{/ts}
+  </div>
+  <div class="crm-content">
+      {if $syncStatus_xero == 0}
+        <a href='#' id='xero-sync' data-contact-id={$contactID_xero}>{ts}Queue Sync to Xero{/ts}</a>
+      {elseif $syncStatus_xero == 1}
+          {ts}Contact is synced with Xero{/ts}
+      {elseif $syncStatus_xero == 2}
+          {ts}Contact is queued for sync with Xero{/ts}
+      {elseif $syncStatus_xero == 3}
+          {ts}Error getting sync status{/ts}
+      {/if}
+  </div>
 
-        {literal}
-            <script type="text/javascript">
-                cj('#xero-sync').click(function( event) {
-                    event.preventDefault();
-                    CRM.api('account_contact', 'create',{
-                        'contact_id' : cj(this).data('contact-id'),
-                        'plugin' : 'xero',
-                        'accounts_needs_update' : 1,
-                    });
-                    cj(this).replaceWith('Contact is queued for sync with Xero');
-                });
-            </script>
+    {if $syncStatus_xero == 0}
+    {literal}
+      <script type="text/javascript">
+        CRM.$('#xero-sync').click(function(event) {
+          event.preventDefault();
+          CRM.api3('account_contact', 'create',{
+            'contact_id' : CRM.$(this).data('contact-id'),
+            'plugin' : 'xero',
+            'accounts_needs_update' : 1,
+          }).done(function(result) {
+            if (result.hasOwnProperty('error_message')) {
+              CRM.$('#xero-sync').replaceWith(result.error_message);
+            }
+            else {
+              CRM.$('#xero-sync').replaceWith('{/literal}{ts}Contact is queued for sync with Xero{/ts}{literal}');
+            }
+          });
+        });
+      </script>
 
-        {/literal}
-    </div>
-{/if}
+    {/literal}
+    {/if}
+</div>


### PR DESCRIPTION
Extracted from #101

If an error occurs the contact summary would just display "queue sync to xero" instead of indicating that an error occurred. Now it indicates that an error occurred and endlessly clicking "queue sync to xero" isn't going to help..