### PR TITLE
If Xero API throttles us wait for one hour before retrying

### DIFF
--- a/CRM/Civixero/Base.php
+++ b/CRM/Civixero/Base.php
@@ -273,4 +273,40 @@ class CRM_Civixero_Base {
     );
   }
 
+  /**
+   * @param bool $throwException
+   *
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  public static function isApiRateLimitExceeded($throwException = FALSE) {
+    $rateLimitExceeded = \Civi::settings()->get('xero_oauth_rate_exceeded');
+    if (!$rateLimitExceeded) {
+      return FALSE;
+    }
+    // Wait for 1 hour if rate limit was exceeded and then retry
+    if (strtotime('+1 hours', $rateLimitExceeded) > time()) {
+      if ($throwException) {
+        throw new CRM_Core_Exception('Rate limit was previously triggered. Try again in 1 hour');
+      }
+      return TRUE;
+    }
+    self::resetApiRateLimitExceeded();
+    return FALSE;
+  }
+
+  /**
+   * @return void
+   */
+  public static function setApiRateLimitExceeded() {
+    \Civi::settings()->set('xero_oauth_rate_exceeded', time());
+  }
+
+  /**
+   * @return void
+   */
+  public static function resetApiRateLimitExceeded() {
+    \Civi::settings()->set('xero_oauth_rate_exceeded', NULL);
+  }
+
 }

--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -21,8 +21,11 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
     // If we specify a xero contact id (UUID) then we try to load ONLY that contact.
     $params['xero_contact_id'] = $params['xero_contact_id'] ?? FALSE;
     try {
+      CRM_Civixero_Base::isApiRateLimitExceeded(TRUE);
+
       /** @noinspection PhpUndefinedMethodInspection */
-      $result = $this->getSingleton($params['connector_id'])
+      $result = $this
+        ->getSingleton($params['connector_id'])
         ->Contacts($params['xero_contact_id'], $this->formatDateForXero($params['start_date']));
       if (!is_array($result)) {
         throw new CRM_Core_Exception('Sync Failed', 'xero_retrieve_failure', (array) $result);
@@ -87,6 +90,7 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
    */
   public function push(array $params): bool {
     try {
+      CRM_Civixero_Base::isApiRateLimitExceeded(TRUE);
       $accountContacts = AccountContact::get(FALSE)
         ->addWhere('plugin', '=', $this->_plugin)
         ->addWhere('accounts_needs_update', '=', TRUE)

--- a/CRM/Civixero/Exception/XeroThrottle.php
+++ b/CRM/Civixero/Exception/XeroThrottle.php
@@ -17,7 +17,8 @@ class CRM_Civixero_Exception_XeroThrottle extends Exception {
    */
   public function __construct($message) {
     parent::__construct(ts($message));
-    Civi::log('civixero')->error('Xero Oath rate exceeded: ' . $message);
+    Civi::log('civixero')->error('Xero Oauth rate exceeded: ' . $message);
+    CRM_Civixero_Base::setApiRateLimitExceeded();
   }
 
 }

--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -41,7 +41,11 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
     $xeroParams = ['Type' => 'ACCREC'];
     $filter = $params['invoice_number'] ?? FALSE;
     try {
-      $result = $this->getSingleton($params['connector_id'])
+      CRM_Civixero_Base::isApiRateLimitExceeded(TRUE);
+
+      $count = 0;
+      $result = $this
+        ->getSingleton($params['connector_id'])
         ->Invoices($filter, $this->formatDateForXero($params['start_date']), $xeroParams);
       if (!is_array($result)) {
         throw new API_Exception('Sync Failed', 'xero_retrieve_failure', (array) $result);
@@ -58,7 +62,6 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
           $prefix = '';
         }
 
-        $count = 0;
         foreach ($invoices as $invoice) {
           $save = TRUE;
           // Strip out the invoice number prefix if present.
@@ -143,6 +146,7 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
    */
   public function push($params, $limit = 10) {
     try {
+      CRM_Civixero_Base::isApiRateLimitExceeded(TRUE);
       $records = $this->getContributionsRequiringPushUpdate($params, $limit);
       $errors = [];
 

--- a/settings/Civixero.setting.php
+++ b/settings/Civixero.setting.php
@@ -160,4 +160,13 @@ return [
     'pseudoconstant' => ['callback' => 'CRM_Civixero_Contact::getLocationTypes'],
     'settings_pages' => ['xero' => ['weight' => 4]],
   ],
+  'xero_oauth_rate_exceeded' => [
+    'name' => 'xero_oauth_rate_exceeded',
+    'type' => 'String',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'default' => '',
+    'title' => 'Xero OAuth Rate Exceeded',
+    'description' => 'Timestamp when OAuth Rate was exceeded. Cleared after one hour',
+  ],
 ];


### PR DESCRIPTION
If something is going wrong  or you're trying to do an initial big sync-up CiviXero will repeatedly try to do that wrong thing. That'll quickly cause you to hit API limits with Xero and we should be respecting that limit (ie. XeroThrottleException) and not just blindly retrying when Xero is telling us not to.

This implements a simple set/reset for the Xero throttle that will prevent sync jobs running for 1 hour if the rate has been exceeded.