### PR TITLE
Access token expiry

### DIFF
--- a/Civixero.php
+++ b/Civixero.php
@@ -184,6 +184,7 @@ function civixero_civicrm_check(array &$messages) {
       'fa-refresh'
     );
   }
+
   $clientID = Civi::settings()->get('xero_client_id');
   $clientSecret = Civi::settings()->get('xero_client_secret');
   $accessTokenData = Civi::settings()->get('xero_access_token');
@@ -204,7 +205,15 @@ function civixero_civicrm_check(array &$messages) {
       LogLevel::WARNING,
       'fa-flag'
     );
-
+  }
+  elseif (isset($accessTokenData['expires']) && ($accessTokenData['expires'] <= time())) {
+    $messages[] = new CRM_Utils_Check_Message(
+      'civixero_authorization_required',
+      ts('Xero access token has expired. You need to re-authorize with Xero to re-enable the connection.'),
+      ts('Xero Authorization Required'),
+      LogLevel::CRITICAL,
+      'fa-flag'
+    );
   }
 }
 

--- a/templates/CRM/Civixero/Form/XeroAuthorize.tpl
+++ b/templates/CRM/Civixero/Form/XeroAuthorize.tpl
@@ -9,6 +9,11 @@
   <div class="content">{$form.xero_client_secret.html}</div>
   <div class="clear"></div>
 </div>
+<div class="crm-section">
+  <div class="label">{ts}Access token expiry date{/ts}</div>
+  <div class="content">{$accesstoken_expiry_date|crmDate}</div>
+  <p class="help">The access token is valid for 30 minutes. It is automatically renewed.</p>
+</div>
 
 <h3>{ts}Status{/ts}</h3>
 <div class="crm-section">


### PR DESCRIPTION
Sometimes you need to re-authorize and you start getting errors in job logs 'invalid_grant'. Make it a bit more friendly/clearer by providing system check and showing expiry date.

Quickbooks has a fixed expiry time for the refresh token. Xero gets a new refresh token (valid for 60 days) every time it gets a new access token (valid for 30 minutes). So in theory it should never expire / need re-authorization. But that's not actually true and sometimes it just starts announcing "invalid_grant" in the sync logs which actually means the you need to re-authorize with Xero.

This PR is probably not a perfect solution but it makes it a bit more user-visible as to what needs to be done to make it work and also to troubleshoot / debug.