### PR TITLE
If no AccountContact record show 'Queue sync to Xero' link

### DIFF
--- a/templates/CRM/Civixero/Page/Inline/ContactSyncStatus.tpl
+++ b/templates/CRM/Civixero/Page/Inline/ContactSyncStatus.tpl
@@ -9,8 +9,6 @@
           {ts}Contact is synced with Xero{/ts}
       {elseif $syncStatus_xero == 2}
           {ts}Contact is queued for sync with Xero{/ts}
-      {elseif $syncStatus_xero == 3}
-          {ts}Error getting sync status{/ts}
       {/if}
   </div>
 


### PR DESCRIPTION
This modifies logic that I put in place recently. It's actually ok for there not to be an AccountContact record but there should be a way to create one. This makes it possible again.