### PR TITLE
Fix fatal error on contact push sched job

### DIFF
--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -153,7 +153,7 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
             ->addWhere('accounts_contact_id', '=', $result['Contacts']['Contact']['ContactID'])
             ->addWhere('plugin', '=', $this->_plugin)
             ->addWhere('connector_id', '=', $params['connector_id'])
-            ->execute()->first();
+            ->execute()->first() ?? [];
 
           if (count($matching)) {
             if (empty($matching['contact_id']) ||


### PR DESCRIPTION
Contact push job fails with:

```
TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in
.../web/sites/default/civicrm/ext/nz.co.fuzion.civixero/CRM/Civixero/Contact.php on line 160 #0 
.../web/sites/default/civicrm/ext/nz.co.fuzion.civixero/api/v3/Civixero/Contactpush.php(50): CRM_Civixero_Contact->push()
```

I think checking for null is a fine change? @eileenmcnaughton 