### PR TITLE
Fix invoice and contact push errors

### DIFF
--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -107,6 +107,7 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
         $accountContacts->addWhere('accounts_needs_update', '=', TRUE);
       }
       $accountContacts->setLimit($params['limit'] ?? 10);
+      $accountContacts->addOrderBy('error_data', 'ASC');
 
       $records = $accountContacts->execute();
 
@@ -183,13 +184,13 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
           // This will update the last sync date.
           $record['accounts_needs_update'] = 0;
           unset($record['last_sync_date']);
-          civicrm_api3('AccountContact', 'create', $record);
         }
         catch (CRM_Core_Exception $e) {
           $errors[] = E::ts('Failed to push ') . $record['contact_id'] . ' (' . $record['accounts_contact_id'] . ' )'
             . E::ts(' with error ') . $e->getMessage() . print_r($responseErrors ?? [], TRUE)
             . E::ts('Contact Push failed');
         }
+        civicrm_api3('AccountContact', 'create', $record);
       }
       if ($errors) {
         // since we expect this to wind up in the job log we'll print the errors

--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -103,8 +103,10 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
         $accountContacts->addWhere('contact_id', '=', $params['contact_id']);
       }
       else {
+        $accountContacts->addWhere('contact_id', 'IS NOT NULL');
         $accountContacts->addWhere('accounts_needs_update', '=', TRUE);
       }
+      $accountContacts->setLimit($params['limit'] ?? 10);
 
       $records = $accountContacts->execute();
 

--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -383,7 +383,7 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
       'accounts_needs_update' => 1,
       'plugin' => 'xero',
       'connector_id' => $params['connector_id'],
-      'accounts_status_id' => ['NOT IN' => [3]],
+      ['OR', [['accounts_status_id', '!=', 3], ['accounts_status_id', 'IS NULL']]],
       'options' => [
         'sort' => 'error_data',
         'limit' => $limit,


### PR DESCRIPTION
**Contact Push Errors:**

- The contact push job queues all the rows to push to xero even when there's no contact_id attached to the account_contact. These rows are normally created from contact pull job and is left to the admins to create a related civi contact for it. I dont think they should be tried to push to xero unless they have a matching civi contact? Hence the condition added.

      $accountContacts->addWhere('contact_id', 'IS NOT NULL');

- OAuth API limit for xero is [60 calls per minute](https://developer.xero.com/documentation/guides/oauth2/limits/#api-rate-limits), but looks like contact push job dont have any limits provided to the sched job. Logs are filled with `Contact Push aborted due to throttling by Xero` messages. Added one now with a default limit for 10 per cron execution.

      $accountContacts->setLimit($params['limit'] ?? 10);

**Invoice Push Errors:**

- Not sure if this needs to be considered as the API4 issue, but looks like `'accounts_status_id' => ['NOT IN' => [3]],` isn't able to retrieve the account_invoice row if `accounts_status_id` is NULL in the table. Due to this, those rows are never fetched and are not pushed to Xero. I've added an additional OR to fix this problem.

      ['OR', [['accounts_status_id', '!=', 3], ['accounts_status_id', 'IS NULL']]],