### PR TITLE
Fix fatal error on invoice push job

### DIFF
--- a/CRM/Civixero/BankTransaction.php
+++ b/CRM/Civixero/BankTransaction.php
@@ -135,7 +135,7 @@ class CRM_Civixero_BankTransaction extends CRM_Civixero_Invoice {
    *
    * @return array
    */
-  protected function getNotUpdateCandidateResponses() {
+  protected function getNotUpdateCandidateResponses(): array {
     return [
       'This Bank Transaction cannot be edited as it has been reconciled with a Bank Statement.',
     ];

--- a/packages/Xero/Xero.php
+++ b/packages/Xero/Xero.php
@@ -252,7 +252,7 @@ class Xero {
         $headers[] = "If-Modified-Since: $modified_after";
       }
       $temp_xero_response = (string) $this->getGuzzleClient()->get($xero_url, [
-        'body' => $nvpreq,
+        'body' => '',
         'curl' => [
           CURLOPT_RETURNTRANSFER => TRUE,
           // Seems bad, historically set to this.


### PR DESCRIPTION
Regression due to https://github.com/eileenmcnaughton/nz.co.fuzion.civixero/commit/4d580a01f36fee1fe33c72e8b971f94b106a642d?

>Got error 'PHP message: PHP Fatal error:  Declaration of CRM_Civixero_BankTransaction::getNotUpdateCandidateResponses() must be compatible with CRM_Civixero_Invoice::getNotUpdateCandidateResponses(): array in /sites/default/civicrm/extensions/nz.co.fuzion.civixero/CRM/Civixero/BankTransaction.php on line 138PHP message: PHP Stack trace:PHP message: PHP   

Stopped cron from running and no invoice being pushed to xero.

PR also removes an undefined variable `$nvpreq` from packages/Xero/Xero.php.