### PR TITLE
Don't trigger update on accounts_data change.

### DIFF
--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -122,7 +122,6 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
               'accounts_modified_date',
               'accounts_contact_id',
               'accounts_needs_update',
-              'accounts_data',
             ];
             foreach ($modifiedFieldKeys as $key) {
               // Every time we do an "update" last_sync_date is updated which triggers an entry in log_civicrm_account_contact.

--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -115,7 +115,6 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
               'accounts_modified_date',
               'accounts_status_id',
               'accounts_needs_update',
-              'accounts_data',
             ];
             foreach ($modifiedFieldKeys as $key) {
               // Every time we do an "update" last_sync_date is updated which triggers an entry in log_civicrm_account_contact.


### PR DESCRIPTION
One of the other fields will be modified if we need to update and this reduces the amount of updates we do (which reduces the amount of logging if extended logging enabled)