### PR TITLE
Don't sync contacts marked do not sync

### DIFF
--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -413,6 +413,7 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
     $accountContacts = AccountContact::get(FALSE)
       ->addWhere('plugin', '=', $this->_plugin)
       ->addWhere('connector_id', '=', $params['connector_id'])
+      ->addWhere('do_not_sync', '<>', TRUE)
       ->setLimit($limit);
 
     // If we specified a CiviCRM contact ID just push that contact.


### PR DESCRIPTION
Change by @jitendrapurohit 

This adds an additional condition to building the list of contacts to sync.

Currently if a Contact is deleted we hit -> https://github.com/eileenmcnaughton/nz.co.fuzion.civixero/blob/2028010f7097ca20e8370884eca6eda3da5fdff6/CRM/Civixero/Contact.php#L182

Which sets do not sync - However - we don't add this to our query to build a list of contacts in getContactsRequiringPushUpdate - in which we set a limit.

So as soon as we have more deleted contacts than the limit we have problems! As in the process to push the contacts in we set this field then move on without doing anything.

Note it looks like this field existed in the 3.x version and wasn't really honoured there either. however I could be wrong.

