### PR TITLE
Fix invoice job to process accounts_status_id = NULL contributions

### DIFF
--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -428,7 +428,7 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
     $accountInvoices = AccountInvoice::get(FALSE)
       ->addWhere('plugin', '=', 'xero')
       ->addWhere('connector_id', '=', $params['connector_id'])
-      ->addWhere('accounts_status_id', 'NOT IN', [CRM_Core_PseudoConstant::getKey('CRM_Accountsync_BAO_AccountInvoice', 'accounts_status_id', 'cancelled')])
+      ->addClause('OR', ['accounts_status_id', 'IS NULL'], ['accounts_status_id', 'NOT IN', [CRM_Core_PseudoConstant::getKey('CRM_Accountsync_BAO_AccountInvoice', 'accounts_status_id', 'cancelled')]])
       ->addOrderBy('error_data')
       ->setLimit($limit);
 


### PR DESCRIPTION
Contribution invoices with accounts_status_id = NULL isn't processed by the scheduled job. This was fixed in https://github.com/eileenmcnaughton/nz.co.fuzion.civixero/pull/132 but the PR was closed as most of the fixed were already included in MJW branch. The problem with accounts_status_id is still there.