### PR TITLE
Rename Xero 'ID' vars for clarity. If invoice UUID is passed in add it to the invoice

### DIFF
--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -196,8 +196,8 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
           $contact = array_merge($contact, $contactAddress);
         }
 
-        $accountsContactID = !empty($record['accounts_contact_id']) ? $record['accounts_contact_id'] : NULL;
-        $accountsContact = $this->mapToAccounts($contact, $accountsContactID);
+        $xeroContactUUID = !empty($record['accounts_contact_id']) ? $record['accounts_contact_id'] : NULL;
+        $accountsContact = $this->mapToAccounts($contact, $xeroContactUUID);
         if ($accountsContact === FALSE) {
           $result = FALSE;
           $responseErrors = [];
@@ -436,12 +436,12 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
    *
    * @param array $contact
    *          Contact Array as returned from API
-   * @param string|null $accountsContactID
+   * @param string|null $xeroContactUUID
    *
    * @return array|bool
    *   Contact Object/ array as expected by accounts package
    */
-  protected function mapToAccounts(array $contact, ?string $accountsContactID) {
+  protected function mapToAccounts(array $contact, ?string $xeroContactUUID) {
     $new_contact = [
       'Name' => $contact['display_name'] . ' - ' . $contact['id'],
       'FirstName' => $contact['first_name'] ?? '',
@@ -470,8 +470,8 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
         ],
       ],
     ];
-    if (!empty($accountsContactID)) {
-      $new_contact['ContactID'] = $accountsContactID;
+    if (!empty($xeroContactUUID)) {
+      $new_contact['ContactID'] = $xeroContactUUID;
     }
     $proceed = TRUE;
     CRM_Accountsync_Hook::accountPushAlterMapped('contact', $contact, $proceed, $new_contact);


### PR DESCRIPTION
Clarify some variables. I was looking into https://github.com/eileenmcnaughton/nz.co.fuzion.civixero/issues/165 and getting confused.