### PR TITLE
Throw exception on curl error instead of undefined variable xero_response

### DIFF
--- a/packages/Xero/Xero.php
+++ b/packages/Xero/Xero.php
@@ -341,6 +341,9 @@ class Xero {
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         $xero_response = curl_exec($ch);
+        if (!$xero_response) {
+          throw new XeroException(curl_error($ch));
+        }
       }
 
       if (isset($fh)) {


### PR DESCRIPTION
If `curl_exec()` fails it returns FALSE or something falsey which causes line 351 `throw new XeroException($xero_response);` to emit a PHP warning about undefined variable.