### PR TITLE
If we have deleted a contribution in CiviCRM don't trigger DB constraint error when saving AccountInvoice

### DIFF
--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -124,6 +124,11 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
                   // Probably we manually reconciled it at some point.
                   unset($accountInvoiceParams['contribution_id']);
                 }
+                if (empty(Contribution::get(FALSE)->addWhere('id', '=', $accountInvoiceParams['contribution_id'])->execute()->first())) {
+                  // This happens if we deleted the contribution in CiviCRM
+                  unset($accountInvoiceParams['contribution_id']);
+                  $accountInvoiceParams['error_data'] = json_encode(['error' => 'No matching contribution found in CiviCRM']);
+                }
                 $newAccountInvoice = AccountInvoice::update(FALSE)
                   ->setValues($accountInvoiceParams)
                   ->addWhere('id', '=', $accountInvoice['id'])


### PR DESCRIPTION
The code derives the contribution ID from the Xero Invoice ID but then crashes when saving because the contribution ID doesn't exist and it triggers a foreign key constraint on contribution.