### PR TITLE
Use newer Xero API from SDK library for Contact Pull and Invoice Pull

### DIFF
--- a/Civi/Api4/Action/Xero/ContactPull.php
+++ b/Civi/Api4/Action/Xero/ContactPull.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Civi\Api4\Action\Xero;
+
+use CRM_Civixero_ExtensionUtil as E;
+
+/**
+ * This API Action retrieves Items from Xero
+ *
+ */
+class ContactPull extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * Connector ID (default 0)
+   *
+   * @var int
+   */
+  protected int $connectorID = 0;
+
+  /**
+   * @var string
+   */
+  protected string $searchTerm = '';
+
+  /**
+   * @var string
+   */
+  protected string $ifModifiedSinceDateTime = '-1 week';
+
+  /**
+   * @var bool
+   */
+  protected bool $includeArchived = FALSE;
+
+  /**
+   * @var bool
+   */
+  protected bool $summaryOnly = FALSE;
+
+  /**
+   * @var int
+   */
+  protected int $page = 1;
+
+  /**
+   * @var int
+   */
+  protected int $pageSize = 100;
+
+  /**
+   *
+   * Note that the result class is that of the annotation below, not the h
+   * in the method (which must match the parent class)
+   *
+   * @var \Civi\Api4\Generic\Result $result
+   */
+  public function _run(\Civi\Api4\Generic\Result $result) {
+    $params = ['connector_id' => $this->connectorID];
+    $xero = new \CRM_Civixero_Contact($params);
+    $items = $xero->pullFromXero($filters ?? [], $this->includeArchived, $this->summaryOnly, $this->searchTerm, $this->page, $this->pageSize, $this->ifModifiedSinceDateTime);
+    $result->exchangeArray($items ?? []);
+    return $result;
+  }
+
+}

--- a/Civi/Api4/Action/Xero/InvoicePull.php
+++ b/Civi/Api4/Action/Xero/InvoicePull.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Civi\Api4\Action\Xero;
+
+use CRM_Civixero_ExtensionUtil as E;
+
+/**
+ * This API Action retrieves Items from Xero
+ *
+ */
+class InvoicePull extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * Connector ID (default 0)
+   *
+   * @var int
+   */
+  protected int $connectorID = 0;
+
+  /**
+   * @var string
+   */
+  protected string $searchTerm = '';
+
+  /**
+   * @var string
+   */
+  protected string $ifModifiedSinceDateTime = '-1 week';
+
+  /**
+   * @var bool
+   */
+  protected bool $includeArchived = FALSE;
+
+  /**
+   * @var bool
+   */
+  protected bool $summaryOnly = FALSE;
+
+  /**
+   * @var int
+   */
+  protected int $page = 1;
+
+  /**
+   * @var int
+   */
+  protected int $pageSize = 100;
+
+  /**
+   *
+   * Note that the result class is that of the annotation below, not the h
+   * in the method (which must match the parent class)
+   *
+   * @var \Civi\Api4\Generic\Result $result
+   */
+  public function _run(\Civi\Api4\Generic\Result $result) {
+    $params = ['connector_id' => $this->connectorID];
+    $xero = new \CRM_Civixero_Invoice($params);
+    $items = $xero->pullFromXero($this->includeArchived, $this->summaryOnly, $this->searchTerm, $this->page, $this->pageSize, $this->ifModifiedSinceDateTime);
+    $result->exchangeArray($items ?? []);
+    return $result;
+  }
+
+}

--- a/api/v3/Civixero/Contactpull.php
+++ b/api/v3/Civixero/Contactpull.php
@@ -47,6 +47,6 @@ function _civicrm_api3_civixero_contactpull_spec(&$spec) {
  */
 function civicrm_api3_civixero_contactpull($params) {
   $xero = new CRM_Civixero_Contact($params);
-  $xero->pull($params);
+  $xero->pullUsingApi4($params);
   return civicrm_api3_create_success(1, $params, 'Civixero', 'contactpull');
 }

--- a/api/v3/Civixero/Invoicepull.php
+++ b/api/v3/Civixero/Invoicepull.php
@@ -59,6 +59,6 @@ function _civicrm_api3_civixero_invoicepull_spec(&$spec) {
  */
 function civicrm_api3_civixero_invoicepull(array $params): array {
   $xero = new CRM_Civixero_Invoice($params);
-  $result = $xero->pull($params);
-  return civicrm_api3_create_success($result, $params);
+  $xero->pullUsingApi4($params);
+  return civicrm_api3_create_success(1, $params);
 }


### PR DESCRIPTION
This switches over Contact and Invoice Pull to use the newer Xero API from the SDK library. The new library also gives us quite a bit of flexibility in terms of params that could be passed but I've not really used those yet and am just parsing existing params in so it stays compatible.

Added API4 for ContactPull and InvoicePull - they don't currently perform the sync though and we might want to consider renaming them or making them do the sync as well. It's useful for debug to be able to pull data from Xero without syncing so useful to have those APIs. But we should eventually replace the API3 calls that currently do the sync.

It also fixes a nasty bug that at some point the scheduled jobs stopped respecting the "start_date" for sync and have started pulling *all* contacts/invoices instead of only those modified in the last day/week etc. Not sure when that happened but had a site slow down to a crawl and run out of memory and investigation showed that it was pulling rather a lot from Xero!