### PR TITLE
Don't try to push Completed invoices if they already exist in Xero

### DIFF
--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -21,6 +21,23 @@ use XeroAPI\XeroPHP\Models\Accounting\LineItemTracking;
 class CRM_Civixero_Invoice extends CRM_Civixero_Base {
 
   /**
+   * Error codes for CRM_Core_Exceptions thrown by getMappedAccountInvoice()/mapToAccounts()
+   * that represent a genuine no-op (nothing to push, nothing wrong) rather than a real
+   * error - see push()'s handling of these below.
+   */
+  private const ERROR_CODE_ALREADY_COMPLETED_IN_XERO = 'already_completed_in_xero';
+
+  private const ERROR_CODE_CANCELLED = 'invoice_cancelled';
+
+  private const ERROR_CODE_HOOK_SKIPPED = 'hook_skipped';
+
+  private const RESOLVED_ERROR_CODES = [
+    self::ERROR_CODE_ALREADY_COMPLETED_IN_XERO,
+    self::ERROR_CODE_CANCELLED,
+    self::ERROR_CODE_HOOK_SKIPPED,
+  ];
+
+  /**
    * Name in Xero of entity.
    *
    * @var string
@@ -302,25 +319,27 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
             // Contact not yet synced to Xero — leave accounts_needs_update set and try again next run.
             continue;
           }
-          if ($mappedAccountInvoice === FALSE) {
-            // We need to set an error so that they are not selected for push next time otherwise we'll keep trying to push the same ones
-            AccountInvoice::update(FALSE)
-              ->addWhere('id', '=', $accountInvoice['id'])
-              ->addValue('error_data', json_encode(['error' => 'Ignored via accountPushAlterMapped hook']))
-              ->addValue('is_error_resolved', FALSE)
-              ->addValue('accounts_needs_update', FALSE)
-              ->execute();
-            // Hook accountPushAlterMapped might set $accountsInvoice to FALSE if we should not sync
-            continue;
-          }
         }
         catch (CRM_Core_Exception $e) {
+          // getMappedAccountInvoice()/mapToAccounts() throw some exceptions (already
+          // completed in Xero, cancelled, vetoed by the accountPushAlterMapped hook) that
+          // are a genuine no-op rather than a real error - mark those resolved so they
+          // don't show up in error reports, and don't count them as failures below.
+          $isErrorResolved = in_array($e->getErrorCode(), self::RESOLVED_ERROR_CODES, TRUE);
           // We need to set an error so that they are not selected for push next time otherwise we'll keep trying to push the same ones
           AccountInvoice::update(FALSE)
             ->addWhere('id', '=', $accountInvoice['id'])
-            ->addValue('error_data', json_encode(['error' => $e->getMessage()]))
+            ->addValue('error_data', json_encode([
+              'error' => $e->getMessage(),
+              'error_data' => $accountInvoice['error_data'],
+            ]))
+            ->addValue('is_error_resolved', $isErrorResolved)
             ->addValue('accounts_needs_update', FALSE)
+            ->addValue('accounts_data', json_encode($accountInvoice))
             ->execute();
+          if (!$isErrorResolved) {
+            $errors[] = $e->getMessage();
+          }
           continue;
         }
         try {
@@ -370,11 +389,11 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
    * @param ?string $xeroInvoiceUUID
    *   The Xero invoice uuid.
    *
-   * @return array|bool
-   *   Contact Object/ array as expected by accounts package
+   * @return array
+   *   Invoice array as expected by accounts package
    * @throws \CRM_Core_Exception
    */
-  protected function mapToAccounts(array $invoiceData, ?string $xeroInvoiceUUID) {
+  protected function mapToAccounts(array $invoiceData, ?string $xeroInvoiceUUID): array {
     // Get the tax mode from the CiviCRM setting. This should be 'exclusive' if
     // tax is enabled (but for historical reasons we force that later on).
     $line_amount_types = Civi::settings()->get('xero_tax_mode');
@@ -440,7 +459,7 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
     $proceed = TRUE;
     CRM_Accountsync_Hook::accountPushAlterMapped('invoice', $invoiceData, $proceed, $new_invoice);
     if (!$proceed) {
-      throw new CRM_Core_Exception('Ignored via accountPushAlterMapped hook');
+      throw new CRM_Core_Exception('Ignored via accountPushAlterMapped hook', self::ERROR_CODE_HOOK_SKIPPED);
     }
 
     $this->validatePrerequisites($new_invoice);
@@ -576,6 +595,7 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
    */
   protected function getAccountInvoicesToPush(array $params, int $limit): array {
     $accountInvoices = AccountInvoice::get(FALSE)
+      ->addSelect('*', 'accounts_status_id:name')
       ->addWhere('plugin', '=', 'xero')
       ->addWhere('connector_id', '=', $params['connector_id'])
       ->addClause('OR', ['accounts_status_id', 'IS NULL'], ['accounts_status_id:name', 'NOT IN', ['cancelled']])
@@ -597,26 +617,41 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
    *
    * @param array $record
    *
-   * @return array|false|null
-   *   Invoice payload for Xero, FALSE to skip permanently, NULL to defer until later.
+   * @return array|null
+   *   Invoice payload for Xero, or NULL to defer until later. Throws (rather than
+   *   returning FALSE) to skip permanently - see RESOLVED_ERROR_CODES.
    * @throws \CRM_Core_Exception
    */
-  protected function getMappedAccountInvoice(array $record): array|null|bool {
+  protected function getMappedAccountInvoice(array $record): ?array {
     if ($record['accounts_status_id'] == CRM_Core_PseudoConstant::getKey('CRM_Accountsync_BAO_AccountInvoice', 'accounts_status_id', 'cancelled')) {
-      throw new CRM_Core_Exception('AccountInvoice is cancelled');
+      throw new CRM_Core_Exception('AccountInvoice is cancelled', self::ERROR_CODE_CANCELLED);
     }
 
     $xeroInvoiceUUID = $record['accounts_invoice_id'] ?? NULL;
     $contributionID = $record['contribution_id'];
+    if (empty($contributionID)) {
+      // This AccountInvoice was created from a Xero invoice that has no matching
+      // CiviCRM contribution yet (create-contribution disabled, or not yet matched
+      // by the pull job) - there is nothing to push.
+      throw new CRM_Core_Exception('Can not push AccountInvoice with no Contribution ID');
+    }
+
     $civiCRMInvoice = civicrm_api3('AccountInvoice', 'getderived', [
       'id' => $contributionID,
     ])['values'][$contributionID] ?? [];
 
-    $contributionStatusName = CRM_Core_PseudoConstant::getName('CRM_Contribute_DAO_Contribution', 'contribution_status_id', $civiCRMInvoice['contribution_status_id']);;
+    $contributionStatusName = CRM_Core_PseudoConstant::getName('CRM_Contribute_DAO_Contribution', 'contribution_status_id', $civiCRMInvoice['contribution_status_id']);
     $cancelledStatuses = ['Failed', 'Cancelled'];
 
     if (empty($civiCRMInvoice) || in_array($contributionStatusName, $cancelledStatuses)) {
       return $this->mapCancelled($contributionID, $xeroInvoiceUUID);
+    }
+
+    if ($xeroInvoiceUUID && $record['accounts_status_id:name'] === 'completed') {
+      // Already Completed (Paid) in Xero - pushing would fail because mapToAccounts()
+      // always pushes using the default invoice status setting, which is never Completed
+      // (e.g. "the status SUBMITTED cannot be applied ... it has payments allocated to it").
+      throw new CRM_Core_Exception('AccountInvoice already completed in Xero', self::ERROR_CODE_ALREADY_COMPLETED_IN_XERO);
     }
 
     // New invoices need a Xero ContactID. If the contact has not been pushed yet,

--- a/tests/phpunit/InvoicePushTest.php
+++ b/tests/phpunit/InvoicePushTest.php
@@ -27,6 +27,19 @@ class InvoicePushTest extends TestCase implements HeadlessInterface, HookInterfa
   use Api3TestTrait;
   use ContactTestTrait;
 
+  /**
+   * Set TRUE within a test to make hook_civicrm_accountPushAlterMapped() veto the mapping.
+   *
+   * @var bool
+   */
+  public bool $vetoPushMapping = FALSE;
+
+  public function hook_civicrm_accountPushAlterMapped($entity, &$data, &$save, &$params) {
+    if ($this->vetoPushMapping) {
+      $save = FALSE;
+    }
+  }
+
   public function setUpHeadless(): CiviEnvBuilder {
     return \Civi\Test::headless()
       ->install('org.civicrm.search_kit')
@@ -206,6 +219,106 @@ class InvoicePushTest extends TestCase implements HeadlessInterface, HookInterfa
     // never attempted.
     $this->assertCount(1, $invoice->pushToXeroCalls);
     $this->assertNotEmpty(Civi::settings()->get('xero_oauth_rate_exceeded'));
+  }
+
+  public function testPushSkipsAndMarksResolvedWhenAlreadyCompletedInXero(): void {
+    $fixture = $this->createQueuedAccountInvoice();
+    $this->callAPISuccess('AccountInvoice', 'create', [
+      'id' => $fixture['account_invoice_id'],
+      'accounts_invoice_id' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      'accounts_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Accountsync_BAO_AccountInvoice', 'accounts_status_id', 'completed'),
+    ]);
+    $invoice = new InvoicePushTestable([]);
+
+    $count = $invoice->push(['connector_id' => 0], 10);
+
+    // Pushing would fail Xero-side (can't apply our default, non-Completed
+    // status to an invoice that already has payments allocated), so it's
+    // skipped before pushToXero() is ever called.
+    $this->assertEquals(0, $count);
+    $this->assertCount(0, $invoice->pushToXeroCalls);
+    $saved = $this->callAPISuccessGetSingle('AccountInvoice', ['id' => $fixture['account_invoice_id']]);
+    $this->assertStringContainsString('already completed in Xero', $saved['error_data']);
+    // Not a real error - nothing to do - so it shouldn't show up in error reports.
+    $this->assertEquals(1, $saved['is_error_resolved']);
+    $this->assertEquals(0, $saved['accounts_needs_update']);
+  }
+
+  public function testPushStillPushesWhenExistingXeroInvoiceIsNotYetCompleted(): void {
+    // The common flow: an invoice was already pushed to Xero (has a UUID)
+    // and is still pending/authorised there - a later push (e.g. an amount
+    // correction, or just re-syncing) must still go through. Only a
+    // Completed/Paid Xero invoice should be skipped.
+    $fixture = $this->createQueuedAccountInvoice();
+    $this->callAPISuccess('AccountInvoice', 'create', [
+      'id' => $fixture['account_invoice_id'],
+      'accounts_invoice_id' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      'accounts_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Accountsync_BAO_AccountInvoice', 'accounts_status_id', 'pending'),
+    ]);
+    $invoice = new InvoicePushTestable([]);
+    $invoice->pushToXeroQueue[] = [
+      'result' => [
+        'Invoices' => [
+          'Invoice' => [
+            'InvoiceID' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+            'UpdatedDateUTC' => '2024-03-15 10:00:00',
+            'Status' => 'AUTHORISED',
+          ],
+        ],
+      ],
+    ];
+
+    $count = $invoice->push(['connector_id' => 0], 10);
+
+    $this->assertEquals(1, $count);
+    $this->assertCount(1, $invoice->pushToXeroCalls);
+    // mapToAccounts() returns [$new_invoice] (a single-element list, not wrapped in an 'Invoice' key).
+    $this->assertEquals('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', $invoice->pushToXeroCalls[0][0]['InvoiceID']);
+  }
+
+  public function testPushSkipsAndMarksResolvedWhenHookVetoesTheMapping(): void {
+    $fixture = $this->createQueuedAccountInvoice();
+    $this->vetoPushMapping = TRUE;
+    $invoice = new InvoicePushTestable([]);
+
+    $count = $invoice->push(['connector_id' => 0], 10);
+
+    $this->assertEquals(0, $count);
+    $this->assertCount(0, $invoice->pushToXeroCalls);
+    $saved = $this->callAPISuccessGetSingle('AccountInvoice', ['id' => $fixture['account_invoice_id']]);
+    $this->assertStringContainsString('Ignored via accountPushAlterMapped hook', $saved['error_data']);
+    // The hook explicitly chose to exclude this invoice - not a real error.
+    $this->assertEquals(1, $saved['is_error_resolved']);
+    $this->assertEquals(0, $saved['accounts_needs_update']);
+  }
+
+  public function testPushRecordsUnresolvedErrorWhenAccountInvoiceHasNoContributionId(): void {
+    // Represents an AccountInvoice pulled from Xero that has no matching
+    // CiviCRM contribution (yet) - previously this crashed push() when it
+    // got as far as mapCancelled(), instead of being skipped cleanly.
+    $accountInvoice = $this->callAPISuccess('AccountInvoice', 'create', [
+      'plugin' => 'xero',
+      'connector_id' => 0,
+      'accounts_invoice_id' => 'aaaaaaaa-bbbb-cccc-dddd-ffffffffffff',
+      'accounts_needs_update' => 1,
+    ]);
+    $invoice = new InvoicePushTestable([]);
+
+    // This is a real problem (not a no-op like the already-completed case), so unlike
+    // that case it counts as a failure and surfaces via the aggregate exception.
+    try {
+      $invoice->push(['connector_id' => 0], 10);
+      $this->fail('Expected push() to throw because the record has no Contribution ID');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertStringContainsString('no Contribution ID', $e->getMessage());
+    }
+
+    $this->assertCount(0, $invoice->pushToXeroCalls);
+    $saved = $this->callAPISuccessGetSingle('AccountInvoice', ['id' => $accountInvoice['id']]);
+    $this->assertStringContainsString('no Contribution ID', $saved['error_data']);
+    $this->assertEquals(0, $saved['is_error_resolved']);
+    $this->assertEquals(0, $saved['accounts_needs_update']);
   }
 
 }


### PR DESCRIPTION
If an invoice already exists in Xero as Completed (Paid), don't try to push it. It will fail because we always push using the default invoice status from the setting `xero_default_invoice_status`: https://github.com/eileenmcnaughton/nz.co.fuzion.civixero/blob/master/CRM/Civixero/Invoice.php#L406 - and that setting has no Completed (Paid) option, so pushing an already-completed invoice just errors, e.g.:
- To update fields on a paid invoice line item, you must supply a LineItemID
- The status SUBMITTED cannot be applied to the invoice because it has payments or credit notes allocated to it.

`getMappedAccountInvoice()` now throws before attempting the push if the AccountInvoice already has a Xero invoice ID *and* is marked Completed there. `push()` records that as a resolved (non-)error rather than surfacing it in error reports, since there's genuinely nothing to do - it isn't skipped permanently, it'll just be re-checked (and re-skipped) each run, same as before this PR for other no-op cases.

This only blocks invoices that are Completed **in Xero**. An invoice that's already been pushed but is still pending/authorised there is pushed again as normal (e.g. amount corrections, re-syncing) - covered by a new test.

Also: don't try to push AccountInvoices that have no Contribution ID - these are invoices that were created in Xero and don't yet exist in CiviCRM. If create-contribution is enabled they'll be matched to a new contribution ID next time the pull job runs. Previously this crashed the whole push job when it hit such a record, because it got as far as `mapCancelled()`, whose `$contributionID` parameter is typed `int` and can't accept the `NULL` id.

## Rebased against current master

This PR was reworked from its original three-commit form to rebase cleanly onto current master:
- The `BankTransaction::mapToAccounts()` signature change and `Invoice::mapToAccounts()` hook-veto throw-instead-of-`FALSE` change from the original commits have since landed separately via other merged work, so they're dropped here - carrying them forward would just be redundant/conflicting.
- The "mark error resolved" logic uses `CRM_Core_Exception` error codes (`already_completed_in_xero`, `invoice_cancelled`, `hook_skipped`) rather than comparing exception messages, per review feedback below - all three no-op cases are now marked resolved, not just the completed-in-Xero one.

No conflicts with the other currently-open civixero PRs (#221, #223, #224, #225) - checked via a merge-tree simulation against each; they touch different methods.

## Tests

Added to `InvoicePushTest.php`:
- `testPushSkipsAndMarksResolvedWhenAlreadyCompletedInXero`
- `testPushStillPushesWhenExistingXeroInvoiceIsNotYetCompleted`
- `testPushSkipsAndMarksResolvedWhenHookVetoesTheMapping`
- `testPushRecordsUnresolvedErrorWhenAccountInvoiceHasNoContributionId`

Full civixero suite passing (41/41), civilint clean relative to this diff.