### PR TITLE
Replace Deprecated Scopes

### DIFF
--- a/CRM/Civixero/OAuth2/Provider/Xero.php
+++ b/CRM/Civixero/OAuth2/Provider/Xero.php
@@ -49,10 +49,20 @@ class CRM_Civixero_OAuth2_Provider_Xero extends \League\OAuth2\Client\Provider\G
     // This may need revising, depending on the operations being performed.
     'offline_access',
     'accounting.settings',
-    'accounting.transactions',
+    'accounting.invoices',
+    'accounting.payments',
+    'accounting.banktransactions',
+    'accounting.manualjournals',
     'accounting.contacts',
     'accounting.journals.read',
-    'accounting.reports.read'
+    'accounting.reports.aged.read',
+    'accounting.reports.balancesheet.read',
+    'accounting.reports.banksummary.read',
+    'accounting.reports.budgetsummary.read',
+    'accounting.reports.executivesummary.read',
+    'accounting.reports.profitandloss.read',
+    'accounting.reports.trialbalance.read',
+    'accounting.reports.taxreports.read'
   ];
 
   /**


### PR DESCRIPTION
## Overview
AS per [this](https://developer.xero.com/documentation/guides/oauth2/scopes/#organisation-scopes) some of the scopes have been deprecated so this PR updates the scopes 