### PR TITLE
Add DRAFT invoice error to the no retry list

### DIFF
--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -693,6 +693,7 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
       'This document cannot be edited as it has a payment or credit note allocated to it.',
       'The status SUBMITTED cannot be applied to the invoice because it has payments or credit notes allocated to it.',
       'The status AUTHORISED cannot be applied to the invoice because it has payments or credit notes allocated to it.',
+      'The status DRAFT cannot be applied to the invoice because it has payments or credit notes allocated to it.',
     ];
   }
 


### PR DESCRIPTION
@eileenmcnaughton :

Follow-up to #204. 
That PR added AUTHORISED to the no-retry list but missed DRAFT. The error "The status DRAFT cannot be applied to the invoice because it has payments or credit notes   allocated to it." has the same root cause — Xero won't accept the update — so it should also stop being retried to avoid consuming the 60 req/min rate limit.

