### PR TITLE
Remove Unused Scope

### DIFF
--- a/CRM/Civixero/OAuth2/Provider/Xero.php
+++ b/CRM/Civixero/OAuth2/Provider/Xero.php
@@ -54,7 +54,6 @@ class CRM_Civixero_OAuth2_Provider_Xero extends \League\OAuth2\Client\Provider\G
     'accounting.banktransactions',
     'accounting.manualjournals',
     'accounting.contacts',
-    'accounting.journals.read',
     'accounting.reports.aged.read',
     'accounting.reports.balancesheet.read',
     'accounting.reports.banksummary.read',


### PR DESCRIPTION
## Overview
[This](https://github.com/eileenmcnaughton/nz.co.fuzion.civixero/pull/206) PR replaces the deprecated scopes with new ones but it also included the `accounting.journals.read` scope which is not used by this extension and it also requires a paid account. So this PR removes this scope