### PR TITLE
Add a Contact Push button to the contact summary

### DIFF
--- a/CRM/Civixero/Page/Inline/ContactSyncStatus.php
+++ b/CRM/Civixero/Page/Inline/ContactSyncStatus.php
@@ -39,6 +39,8 @@ class CRM_Civixero_Page_Inline_ContactSyncStatus extends CRM_Core_Page {
 
     $page->assign('syncStatus_xero', $syncStatus);
     $page->assign('contactID_xero', $contactID);
+    $page->assign('connectorID_xero', $account_contact['connector_id'] ?? 0);
+    $page->assign('canPushXero_xero', CRM_Core_Permission::check('administer CiviCRM system'));
   }
 
 }

--- a/Civixero.php
+++ b/Civixero.php
@@ -360,3 +360,16 @@ function civixero_civicrm_contactSummaryBlocks(&$blocks) {
   ];
 
 }
+
+/**
+ * Implements hook_civicrm_alterAPIPermissions().
+ *
+ * Contactpush is otherwise governed by core's generic 'administer CiviCRM'
+ * default (CRM_Core_Permission::getEntityActionPermissions()); the manual
+ * "Push Now" button on the contact summary page calls this API with
+ * check_permissions set, so declare the (lesser) permission that's
+ * actually required for that on-demand, single-contact push.
+ */
+function civixero_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
+  $permissions['civixero']['contactpush'] = ['administer CiviCRM system'];
+}

--- a/templates/CRM/Civixero/Page/Inline/ContactSyncStatus.tpl
+++ b/templates/CRM/Civixero/Page/Inline/ContactSyncStatus.tpl
@@ -9,6 +9,9 @@
           {ts}Contact is synced with Xero{/ts}
       {elseif $syncStatus_xero == 2}
           {ts}Contact is queued for sync with Xero{/ts}
+          {if $canPushXero_xero}
+            &nbsp;<a href='#' id='xero-push-now' data-contact-id={$contactID_xero} data-connector-id={$connectorID_xero}>{ts}Push Now{/ts}</a>
+          {/if}
       {/if}
   </div>
 
@@ -32,6 +35,28 @@
         });
       </script>
 
+    {/literal}
+    {/if}
+    {if $syncStatus_xero == 2 && $canPushXero_xero}
+    {literal}
+      <script type="text/javascript">
+        CRM.$('#xero-push-now').click(function(event) {
+          event.preventDefault();
+          var $link = CRM.$(this);
+          $link.text('{/literal}{ts escape="js"}Pushing...{/ts}{literal}').off('click');
+          CRM.api3('Civixero', 'contactpush', {
+            'contact_id' : $link.data('contact-id'),
+            'connector_id' : $link.data('connector-id'),
+          }).done(function(result) {
+            if (result.hasOwnProperty('error_message')) {
+              $link.replaceWith(result.error_message);
+            }
+            else {
+              $link.closest('.crm-content').text('{/literal}{ts}Contact is synced with Xero{/ts}{literal}');
+            }
+          });
+        });
+      </script>
     {/literal}
     {/if}
 </div>

--- a/tests/phpunit/ContactPushTest.php
+++ b/tests/phpunit/ContactPushTest.php
@@ -3,6 +3,7 @@
 use Civi\MockConnector;
 use Civi\Test\Api3TestTrait;
 use Civi\Test\CiviEnvBuilder;
+use Civi\Test\ContactTestTrait;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
@@ -25,6 +26,7 @@ use PHPUnit\Framework\TestCase;
 class ContactPushTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
 
   use Api3TestTrait;
+  use ContactTestTrait;
 
   /**
    * Setup used when HeadlessInterface is implemented.
@@ -52,9 +54,48 @@ class ContactPushTest extends TestCase implements HeadlessInterface, HookInterfa
 
   /**
    * Test push.
+   *
+   * No check_permissions is passed, matching how the scheduled "CiviXero
+   * Contact Push Job" invokes this API internally - permission checks must
+   * not apply in that context.
    */
   public function testPush():void {
     $this->callAPISuccess('Civixero', 'contactpush');
+  }
+
+  /**
+   * push() builds its worklist from getContactsRequiringPushUpdate(); when
+   * called with a contact_id it should return only that contact's queued
+   * AccountContact record, not other contacts that are also queued.
+   *
+   * (push() itself isn't exercised here as it requires a real Xero
+   * connection to call getSingleton()->Contacts(); MockConnector only
+   * stands in for the OAuth token exchange.)
+   */
+  public function testGetContactsRequiringPushUpdateIsScopedToOneContact(): void {
+    $targetContactID = $this->individualCreate([], 'target');
+    $otherContactID = $this->individualCreate([], 'other');
+
+    $this->callAPISuccess('AccountContact', 'create', [
+      'contact_id' => $targetContactID,
+      'plugin' => 'xero',
+      'connector_id' => 0,
+      'accounts_needs_update' => 1,
+    ]);
+    $this->callAPISuccess('AccountContact', 'create', [
+      'contact_id' => $otherContactID,
+      'plugin' => 'xero',
+      'connector_id' => 0,
+      'accounts_needs_update' => 1,
+    ]);
+
+    $records = (new CRM_Civixero_Contact([]))->getContactsRequiringPushUpdate([
+      'connector_id' => 0,
+      'contact_id' => $targetContactID,
+    ], 10);
+
+    $this->assertCount(1, $records);
+    $this->assertEquals($targetContactID, $records[0]['contact_id']);
   }
 
 }


### PR DESCRIPTION
This has been on my to do list for a while!

Adds a simple "Push now" link which lets you push immediately (just that contact) from the contact record instead of running the push job manually or waiting for the cron job to run.

<img width="911" height="141" alt="image" src="https://github.com/user-attachments/assets/82295ad9-0910-4164-9838-96c350889972" />

Useful when you are creating a contact specifically because you need to send them an invoice.