### PR TITLE
Add characterization tests for #215's Xero SDK push migration + 3 fixes

### DIFF
--- a/CRM/Civixero/BankTransaction.php
+++ b/CRM/Civixero/BankTransaction.php
@@ -139,7 +139,7 @@ class CRM_Civixero_BankTransaction extends CRM_Civixero_Invoice {
    * @throws \XeroAPI\XeroPHP\ApiException
    * @throws \CRM_Core_Exception
    */
-  private function pushViaApi(array $mapped): array {
+  protected function pushViaApi(array $mapped): array {
     $bankTransaction = new BankTransaction();
     $bankTransaction->setType($mapped['Type'] ?? 'RECEIVE');
     if (!empty($mapped['BankTransactionID'])) {

--- a/CRM/Civixero/Base.php
+++ b/CRM/Civixero/Base.php
@@ -200,6 +200,12 @@ class CRM_Civixero_Base {
       CRM_Civixero_Base::setApiRateLimitExceeded();
       throw new CRM_Civixero_Exception_XeroThrottle($problem);
     }
+    if (!empty($response['ValidationErrors']) && is_array($response['ValidationErrors'])) {
+      // pushViaApi() (xeroapi/xero-php-oauth2 SDK path) returns validation
+      // failures as a top-level ValidationErrors key, rather than the legacy
+      // package's nested Elements.DataContractBase.ValidationErrors shape.
+      return $response['ValidationErrors'];
+    }
     if (!empty($response['ErrorNumber'])) {
       $errors[] = $response['Message'];
     }

--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -760,6 +760,17 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
     catch (XeroThrottleException $e) {
       throw new CRM_Civixero_Exception_XeroThrottle($e->getMessage(), $e->getCode(), $e, $e->getRetryAfter());
     }
+    catch (\XeroAPI\XeroPHP\ApiException $e) {
+      if ($e->getCode() === 429) {
+        $retryAfterSeconds = (int) ($e->getResponseHeaders()['Retry-After'][0] ?? 0);
+        throw new CRM_Civixero_Exception_XeroThrottle($e->getMessage(), $e->getCode(), $e, $retryAfterSeconds ? (time() + $retryAfterSeconds) : NULL);
+      }
+      throw new CRM_Core_Exception(
+        'Synchronization error ' . $e->getMessage(),
+        'xero_' . $e->getCode(),
+        ['response' => $e->getResponseBody()]
+      );
+    }
     catch (XeroException $e) {
       if (method_exists($e, 'getXML') && $e->getXML()) {
         return ArrayToXML::toArray($e->getXML());
@@ -1083,7 +1094,7 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
    * @throws \XeroAPI\XeroPHP\ApiException
    * @throws \CRM_Core_Exception
    */
-  private function pushViaApi(array $mapped): array {
+  protected function pushViaApi(array $mapped): array {
     $invoice = new Invoice();
     $invoice->setType($mapped['Type'] ?? 'ACCREC');
     if (!empty($mapped['InvoiceID'])) {

--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -329,7 +329,7 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
           $count++;
         }
         catch (CRM_Core_Exception $e) {
-          $errorMessage = E::ts('Failed to push contributionID: %1 (AccountsContactID: %2)', [1 => $accountInvoice['contribution_id'], 2 => $accountInvoice['accounts_contact_id']])
+          $errorMessage = E::ts('Failed to push contributionID: %1', [1 => $accountInvoice['contribution_id']])
             . E::ts('Error: ') . $e->getMessage() . print_r($responseErrors ?? [], TRUE)
             . E::ts('%1 Push failed', [1 => $this->xero_entity]);
 

--- a/tests/phpunit/BankTransactionMappingTest.php
+++ b/tests/phpunit/BankTransactionMappingTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use Civi\BankTransactionMappingTestable;
+use Civi\MockConnector;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterization tests for CRM_Civixero_BankTransaction's mapToAccounts().
+ *
+ * BankTransaction largely inherits Invoice's push()/savePushResponse() (see
+ * InvoiceMappingTest/InvoiceResponseHandlingTest for those), but overrides
+ * mapToAccounts() with a different Xero shape (RECEIVE bank transaction
+ * rather than an ACCREC/ACCPAY invoice) and getNotUpdateCandidateResponses().
+ *
+ * @group headless
+ */
+class BankTransactionMappingTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->install('org.civicrm.search_kit')
+      ->install('nz.co.fuzion.accountsync')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp(): void {
+    Civi::$statics['civixero_connector'] = new MockConnector();
+    parent::setUp();
+  }
+
+  private function getBankTransaction(): BankTransactionMappingTestable {
+    return new BankTransactionMappingTestable([]);
+  }
+
+  private function getBasicInvoiceData(): array {
+    return [
+      'id' => 789,
+      'contact_id' => 55,
+      'receive_date' => '2024-03-15 10:00:00',
+      'display_name' => 'Jane Doe',
+      'contribution_source' => 'Donation',
+      'payment_instrument_accounting_code' => '090',
+      'line_items' => [
+        [
+          'display_name' => 'Jane Doe',
+          'label' => 'General Donation',
+          'qty' => 1,
+          'unit_price' => 25,
+          'accounting_code' => '400',
+        ],
+      ],
+    ];
+  }
+
+  public function testMapToAccountsBasicFields(): void {
+    $result = $this->getBankTransaction()->callMapToAccounts($this->getBasicInvoiceData(), NULL);
+
+    $this->assertCount(1, $result);
+    $bankTransaction = $result[0];
+    $this->assertEquals('RECEIVE', $bankTransaction['Type']);
+    // Note: unlike Invoice's mapToAccounts(), the contact is referenced by
+    // ContactNumber (the CiviCRM contact ID), not a Xero ContactID.
+    $this->assertEquals(['ContactNumber' => 55], $bankTransaction['Contact']);
+    $this->assertEquals('2024-03-15', $bankTransaction['Date']);
+    $this->assertEquals('AUTHORISED', $bankTransaction['Status']);
+    $this->assertEquals('Jane Doe Donation', $bankTransaction['Reference']);
+    $this->assertEquals('Inclusive', $bankTransaction['LineAmountTypes']);
+    $this->assertEquals(['Code' => '090'], $bankTransaction['BankAccount']);
+    $this->assertArrayNotHasKey('BankTransactionID', $bankTransaction);
+
+    $lineItem = $bankTransaction['LineItems']['LineItem'][0];
+    $this->assertEquals('Jane Doe General Donation', $lineItem['Description']);
+    $this->assertEquals(1, $lineItem['Quantity']);
+    $this->assertEquals(25, $lineItem['UnitAmount']);
+    $this->assertEquals('400', $lineItem['AccountCode']);
+  }
+
+  public function testMapToAccountsIncludesBankTransactionIDWhenUUIDProvided(): void {
+    $result = $this->getBankTransaction()->callMapToAccounts($this->getBasicInvoiceData(), 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    $this->assertEquals('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', $result[0]['BankTransactionID']);
+  }
+
+  public function testMapToAccountsUsesDefaultAccountCodeWhenLineItemHasNone(): void {
+    $invoiceData = $this->getBasicInvoiceData();
+    unset($invoiceData['line_items'][0]['accounting_code']);
+    $result = $this->getBankTransaction()->callMapToAccounts($invoiceData, NULL);
+    // Default is the xero_default_revenue_account setting, which defaults to 200.
+    $this->assertEquals('200', (string) $result[0]['LineItems']['LineItem'][0]['AccountCode']);
+  }
+
+  public function testGetNotUpdateCandidateResponsesReconciledMessage(): void {
+    $responses = $this->getBankTransaction()->callGetNotUpdateCandidateResponses();
+    $this->assertContains(
+      'This Bank Transaction cannot be edited as it has been reconciled with a Bank Statement.',
+      $responses
+    );
+  }
+
+  public function testIsSplitTransactionsIsTrueForBankTransactions(): void {
+    // Bank transactions (unlike Invoices) support splitting line items across
+    // different connector accounts - see CRM_Civixero_Invoice::isSplitTransactions().
+    $reflection = new ReflectionMethod('CRM_Civixero_BankTransaction', 'isSplitTransactions');
+    $reflection->setAccessible(TRUE);
+    $this->assertTrue($reflection->invoke($this->getBankTransaction()));
+  }
+
+}

--- a/tests/phpunit/BankTransactionSdkPushTest.php
+++ b/tests/phpunit/BankTransactionSdkPushTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use Civi\BankTransactionSdkPushTestable;
+use Civi\MockConnector;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\GuzzleTestTrait;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group headless
+ */
+class BankTransactionSdkPushTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  use GuzzleTestTrait;
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->install('org.civicrm.search_kit')
+      ->install('nz.co.fuzion.accountsync')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp(): void {
+    Civi::$statics['civixero_connector'] = new MockConnector();
+    parent::setUp();
+  }
+
+  /**
+   * CRM_Civixero_BankTransaction no longer overrides pushToXero() after
+   * PR #215 - it inherits CRM_Civixero_Invoice::pushToXero(), which calls
+   * $this->pushViaApi(). Invoice and BankTransaction each declared their own
+   * *private* pushViaApi() - and private methods aren't virtual/overridable
+   * in PHP, so $this->pushViaApi() called from code textually defined in
+   * Invoice.php always resolved to Invoice::pushViaApi(), never
+   * BankTransaction::pushViaApi(), regardless of $this's actual class. That
+   * routed every BankTransaction push through Invoice's SDK model instead of
+   * BankTransaction's, crashing on every single push because 'RECEIVE' (a
+   * valid BankTransaction Type) isn't a valid Invoice Type.
+   *
+   * Fixed by making pushViaApi() protected in both classes so
+   * BankTransaction's override is actually dispatched. This test proves the
+   * BankTransactions endpoint (not Invoices) is hit and the response is
+   * shaped correctly.
+   */
+  public function testBankTransactionPushHitsBankTransactionsEndpointAndReturnsLegacyShape(): void {
+    $this->createMockHandler([
+      json_encode([
+        'BankTransactions' => [
+          ['BankTransactionID' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', 'Status' => 'AUTHORISED', 'UpdatedDateUTC' => '2024-03-15T10:00:00'],
+        ],
+      ]),
+    ]);
+    $this->setUpClientWithHistoryContainer();
+    $bankTransaction = new BankTransactionSdkPushTestable([]);
+    $bankTransaction->mockClient = $this->getGuzzleClient();
+
+    $mapped = [[
+      'Type' => 'RECEIVE',
+      'Contact' => ['ContactNumber' => 55],
+      'Date' => '2024-03-15',
+      'Status' => 'AUTHORISED',
+      'CurrencyCode' => 'NZD',
+      'Reference' => 'Test',
+      'LineAmountTypes' => 'Inclusive',
+      'LineItems' => ['LineItem' => [['Description' => 'Donation', 'Quantity' => 1, 'UnitAmount' => 25, 'AccountCode' => '400']]],
+      'BankAccount' => ['Code' => '090'],
+    ]];
+
+    $result = $bankTransaction->callPushToXero($mapped, 0);
+
+    $urls = $this->getRequestUrls();
+    $this->assertCount(1, $urls);
+    $this->assertStringContainsString('/BankTransactions', $urls[0]);
+    $this->assertEquals(
+      'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      $result['BankTransactions']['BankTransaction']['BankTransactionID']
+    );
+  }
+
+}

--- a/tests/phpunit/Civi/BankTransactionMappingTestable.php
+++ b/tests/phpunit/Civi/BankTransactionMappingTestable.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Civi;
+
+/**
+ * Exposes CRM_Civixero_BankTransaction's protected mapToAccounts() for direct
+ * testing. See InvoiceMappingTestable for why this lives outside a *Test.php
+ * file.
+ */
+class BankTransactionMappingTestable extends \CRM_Civixero_BankTransaction {
+
+  public function callMapToAccounts(array $invoiceData, ?string $xeroInvoiceUUID): array {
+    return $this->mapToAccounts($invoiceData, $xeroInvoiceUUID);
+  }
+
+  public function callGetNotUpdateCandidateResponses(): array {
+    return $this->getNotUpdateCandidateResponses();
+  }
+
+}

--- a/tests/phpunit/Civi/BankTransactionSdkPushTestable.php
+++ b/tests/phpunit/Civi/BankTransactionSdkPushTestable.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Civi;
+
+use GuzzleHttp\ClientInterface;
+use XeroAPI\XeroPHP\Api\AccountingApi;
+use XeroAPI\XeroPHP\Configuration;
+
+/**
+ * See InvoiceSdkPushTestable - same purpose, for CRM_Civixero_BankTransaction.
+ */
+class BankTransactionSdkPushTestable extends \CRM_Civixero_BankTransaction {
+
+  public ClientInterface $mockClient;
+
+  public function getAccountingApiInstance(): AccountingApi {
+    $config = Configuration::getDefaultConfiguration()->setAccessToken($this->getAccessToken());
+    return new AccountingApi($this->mockClient, $config);
+  }
+
+  public function callPushToXero($accountsInvoice, $connector_id) {
+    return $this->pushToXero($accountsInvoice, $connector_id);
+  }
+
+}

--- a/tests/phpunit/Civi/InvoiceMappingTestable.php
+++ b/tests/phpunit/Civi/InvoiceMappingTestable.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Civi;
+
+/**
+ * Exposes CRM_Civixero_Invoice's protected mapping methods for direct testing.
+ *
+ * Lives outside any *Test.php file (like MockConnector) so PHPUnit's eager
+ * file-based test discovery doesn't include_once it - and thus resolve its
+ * `extends` clause - before CiviCRM's headless install has registered the
+ * civixero extension's autoloading.
+ */
+class InvoiceMappingTestable extends \CRM_Civixero_Invoice {
+
+  public function callMapToAccounts(array $invoiceData, ?string $xeroInvoiceUUID): array {
+    return $this->mapToAccounts($invoiceData, $xeroInvoiceUUID);
+  }
+
+  public function callMapCancelled(int $contributionID, ?string $xeroInvoiceUUID): array {
+    return $this->mapCancelled($contributionID, $xeroInvoiceUUID);
+  }
+
+}

--- a/tests/phpunit/Civi/InvoicePushTestable.php
+++ b/tests/phpunit/Civi/InvoicePushTestable.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Civi;
+
+/**
+ * Overrides CRM_Civixero_Invoice::pushToXero() with a canned-response queue,
+ * so push() can be exercised end-to-end without any network access -
+ * regardless of whether pushToXero() itself talks to the legacy Xero
+ * package or the new xeroapi/xero-php-oauth2 SDK. See InvoiceMappingTestable
+ * for why this lives outside a *Test.php file.
+ */
+class InvoicePushTestable extends \CRM_Civixero_Invoice {
+
+  /**
+   * @var array
+   *   Queue of either ['result' => $value] or ['throw' => $exception].
+   */
+  public array $pushToXeroQueue = [];
+
+  /**
+   * @var array
+   *   The $accountsInvoice argument passed to pushToXero() on each call, in order.
+   */
+  public array $pushToXeroCalls = [];
+
+  protected function pushToXero($accountsInvoice, $connector_id) {
+    $this->pushToXeroCalls[] = $accountsInvoice;
+    if ($this->pushToXeroQueue === []) {
+      throw new \LogicException('InvoicePushTestable::pushToXero() called with nothing queued');
+    }
+    $next = array_shift($this->pushToXeroQueue);
+    if (array_key_exists('throw', $next)) {
+      throw $next['throw'];
+    }
+    return $next['result'];
+  }
+
+}

--- a/tests/phpunit/Civi/InvoiceResponseHandlingTestable.php
+++ b/tests/phpunit/Civi/InvoiceResponseHandlingTestable.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Civi;
+
+/**
+ * Exposes CRM_Civixero_Invoice's protected response-handling methods for
+ * direct testing. See InvoiceMappingTestable for why this lives outside a
+ * *Test.php file.
+ */
+class InvoiceResponseHandlingTestable extends \CRM_Civixero_Invoice {
+
+  public function callSavePushResponse($result, $record) {
+    return $this->savePushResponse($result, $record);
+  }
+
+  public function callValidateResponse($response) {
+    return $this->validateResponse($response);
+  }
+
+  public function callIsNotUpdateCandidate($responseErrors): bool {
+    return $this->isNotUpdateCandidate($responseErrors);
+  }
+
+}

--- a/tests/phpunit/Civi/InvoiceSdkPushTestable.php
+++ b/tests/phpunit/Civi/InvoiceSdkPushTestable.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Civi;
+
+use GuzzleHttp\ClientInterface;
+use XeroAPI\XeroPHP\Api\AccountingApi;
+use XeroAPI\XeroPHP\Configuration;
+
+/**
+ * Overrides CRM_Civixero_Invoice::getAccountingApiInstance() so the real SDK
+ * (real request-building/serialization, real response deserialization) can
+ * be exercised against a mocked Guzzle HTTP client instead of the network.
+ * See InvoiceMappingTestable for why this lives outside a *Test.php file.
+ */
+class InvoiceSdkPushTestable extends \CRM_Civixero_Invoice {
+
+  public ClientInterface $mockClient;
+
+  public function getAccountingApiInstance(): AccountingApi {
+    $config = Configuration::getDefaultConfiguration()->setAccessToken($this->getAccessToken());
+    return new AccountingApi($this->mockClient, $config);
+  }
+
+  public function callPushToXero($accountsInvoice, $connector_id) {
+    return $this->pushToXero($accountsInvoice, $connector_id);
+  }
+
+}

--- a/tests/phpunit/InvoiceMappingTest.php
+++ b/tests/phpunit/InvoiceMappingTest.php
@@ -1,0 +1,156 @@
+<?php
+
+use Civi\InvoiceMappingTestable;
+use Civi\MockConnector;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterization tests for CRM_Civixero_Invoice's mapToAccounts()/mapCancelled().
+ *
+ * These pin down the array shape produced today (pre-SDK-migration) from a
+ * CiviCRM-shaped invoice/contribution array. Nothing here touches the
+ * network - mapToAccounts()/mapCancelled() are pure transforms over settings
+ * + input array. The goal is to have something that keeps passing whichever
+ * SDK pushToXero() ends up using, since these methods aren't touched by the
+ * SDK migration - only the code that consumes their output is.
+ *
+ * @group headless
+ */
+class InvoiceMappingTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->install('org.civicrm.search_kit')
+      ->install('nz.co.fuzion.accountsync')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp(): void {
+    Civi::$statics['civixero_connector'] = new MockConnector();
+    // Pin down the invoice-due-date-from-settings branch so it can't leak
+    // in from whatever this site's Contribute settings happen to be.
+    Civi::settings()->set('invoice_due_date', 0);
+    Civi::settings()->set('invoice_due_date_period', 'select');
+    parent::setUp();
+  }
+
+  private function getInvoice(): InvoiceMappingTestable {
+    return new InvoiceMappingTestable([]);
+  }
+
+  private function getBasicInvoiceData(): array {
+    return [
+      'id' => 123,
+      'accounts_contact_id' => '11111111-1111-1111-1111-111111111111',
+      'receive_date' => '2024-03-15 10:00:00',
+      'currency' => 'NZD',
+      'display_name' => 'Jane Doe',
+      'contribution_source' => 'Event registration',
+      'line_items' => [
+        [
+          'display_name' => 'Jane Doe',
+          'label' => 'General Admission',
+          'qty' => 1,
+          'unit_price' => 50,
+          'accounting_code' => '400',
+        ],
+      ],
+    ];
+  }
+
+  public function testMapToAccountsBasicFields(): void {
+    $result = $this->getInvoice()->callMapToAccounts($this->getBasicInvoiceData(), NULL);
+
+    $this->assertCount(1, $result);
+    $invoice = $result[0];
+    $this->assertEquals('ACCREC', $invoice['Type']);
+    $this->assertEquals(['ContactID' => '11111111-1111-1111-1111-111111111111'], $invoice['Contact']);
+    $this->assertEquals('2024-03-15', $invoice['Date']);
+    $this->assertEquals('2024-03-15', $invoice['DueDate']);
+    $this->assertEquals('SUBMITTED', $invoice['Status']);
+    $this->assertEquals('CIVI123', $invoice['InvoiceNumber']);
+    $this->assertEquals('NZD', $invoice['CurrencyCode']);
+    $this->assertEquals('Jane Doe Event registration', $invoice['Reference']);
+    $this->assertEquals('Inclusive', $invoice['LineAmountTypes']);
+    $this->assertArrayNotHasKey('InvoiceID', $invoice);
+
+    $lineItem = $invoice['LineItems']['LineItem'][0];
+    $this->assertEquals('Jane Doe General Admission', $lineItem['Description']);
+    $this->assertEquals(1, $lineItem['Quantity']);
+    $this->assertEquals(50, $lineItem['UnitAmount']);
+    $this->assertEquals('400', $lineItem['AccountCode']);
+  }
+
+  public function testMapToAccountsIncludesInvoiceIDWhenUUIDProvided(): void {
+    $result = $this->getInvoice()->callMapToAccounts($this->getBasicInvoiceData(), 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    $this->assertEquals('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', $result[0]['InvoiceID']);
+  }
+
+  public function testMapToAccountsUsesDefaultAccountCodeWhenLineItemHasNone(): void {
+    $invoiceData = $this->getBasicInvoiceData();
+    unset($invoiceData['line_items'][0]['accounting_code']);
+    $result = $this->getInvoice()->callMapToAccounts($invoiceData, NULL);
+    // Default is the xero_default_revenue_account setting, which defaults to 200.
+    $this->assertEquals('200', (string) $result[0]['LineItems']['LineItem'][0]['AccountCode']);
+  }
+
+  public function testMapToAccountsNegativeTotalFlipsSignAndUsesAccpay(): void {
+    $invoiceData = $this->getBasicInvoiceData();
+    $invoiceData['line_items'][0]['qty'] = -1;
+    $invoiceData['line_items'][0]['unit_price'] = 10;
+
+    $result = $this->getInvoice()->callMapToAccounts($invoiceData, NULL);
+    $invoice = $result[0];
+
+    $this->assertEquals('ACCPAY', $invoice['Type']);
+    $lineItem = $invoice['LineItems']['LineItem'][0];
+    // Quantity is abs()'d, and UnitAmount is flipped back to positive because
+    // the overall total is negative.
+    $this->assertEquals(1, $lineItem['Quantity']);
+    $this->assertEquals(10, $lineItem['UnitAmount']);
+  }
+
+  public function testMapToAccountsNonZeroTaxAmountSwitchesToExclusive(): void {
+    $invoiceData = $this->getBasicInvoiceData();
+    $invoiceData['line_items'][0]['tax_amount'] = '5.00';
+
+    $result = $this->getInvoice()->callMapToAccounts($invoiceData, NULL);
+    // Default xero_tax_mode setting is 'Inclusive', but a non-zero tax_amount
+    // forces 'Exclusive' regardless of the setting.
+    $this->assertEquals('Exclusive', $result[0]['LineAmountTypes']);
+  }
+
+  public function testMapToAccountsZeroTaxAmountStringDoesNotSwitchToExclusive(): void {
+    $invoiceData = $this->getBasicInvoiceData();
+    $invoiceData['line_items'][0]['tax_amount'] = '0.00';
+
+    $result = $this->getInvoice()->callMapToAccounts($invoiceData, NULL);
+    $this->assertEquals('Inclusive', $result[0]['LineAmountTypes']);
+  }
+
+  public function testMapCancelledWithoutUuid(): void {
+    $result = $this->getInvoice()->callMapCancelled(456, NULL);
+
+    $invoice = $result['Invoice'];
+    $this->assertNull($invoice['InvoiceID']);
+    $this->assertEquals('CIVI456', $invoice['InvoiceNumber']);
+    $this->assertEquals('ACCREC', $invoice['Type']);
+    $this->assertEquals('Cancelled', $invoice['Reference']);
+    $this->assertEquals('DRAFT', $invoice['Status']);
+    $this->assertEquals('Exclusive', $invoice['LineAmountTypes']);
+    $this->assertEquals(0, $invoice['LineItems']['LineItem']['Quantity']);
+    $this->assertEquals(0, $invoice['LineItems']['LineItem']['UnitAmount']);
+    $this->assertEquals('200', (string) $invoice['LineItems']['LineItem']['AccountCode']);
+  }
+
+  public function testMapCancelledWithUuid(): void {
+    $result = $this->getInvoice()->callMapCancelled(456, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    $this->assertEquals('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', $result['Invoice']['InvoiceID']);
+  }
+
+}

--- a/tests/phpunit/InvoicePushTest.php
+++ b/tests/phpunit/InvoicePushTest.php
@@ -1,0 +1,211 @@
+<?php
+
+use Civi\InvoicePushTestable;
+use Civi\MockConnector;
+use Civi\Test\Api3TestTrait;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\ContactTestTrait;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * End-to-end characterization tests for CRM_Civixero_Invoice::push().
+ *
+ * push() orchestrates: fetch queued AccountInvoices -> map -> pushToXero() ->
+ * savePushResponse(). pushToXero() is the only piece the Xero-SDK migration
+ * touches, so these tests use InvoicePushTestable to feed it canned
+ * responses/exceptions - proving push()'s surrounding orchestration
+ * (error handling, throttle abort, DB updates) is independent of which SDK
+ * pushToXero() delegates to underneath.
+ *
+ * @group headless
+ */
+class InvoicePushTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  use Api3TestTrait;
+  use ContactTestTrait;
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->install('org.civicrm.search_kit')
+      ->install('nz.co.fuzion.accountsync')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp(): void {
+    Civi::$statics['civixero_connector'] = new MockConnector();
+    CRM_Civixero_Base::resetApiRateLimitExceeded();
+    // Pin down the invoice-due-date-from-settings branch so it can't leak
+    // in from whatever this site's Contribute settings happen to be (and so
+    // mapToAccounts() doesn't hit PHP 8.1's deprecated strftime()).
+    Civi::settings()->set('invoice_due_date', 0);
+    Civi::settings()->set('invoice_due_date_period', 'select');
+    parent::setUp();
+  }
+
+  public function tearDown(): void {
+    CRM_Civixero_Base::resetApiRateLimitExceeded();
+    parent::tearDown();
+  }
+
+  /**
+   * Create a Contribution + AccountContact + queued AccountInvoice, ready
+   * for CRM_Civixero_Invoice::push() to pick up.
+   *
+   * @return array{contribution_id: int, account_invoice_id: int}
+   */
+  private function createQueuedAccountInvoice(): array {
+    $contactID = $this->individualCreate();
+    // accountsync's hook_civicrm_post may have already auto-created an
+    // AccountContact row for this contact (depending on this site's
+    // account_sync settings) - update that row rather than colliding with
+    // its unique index by inserting a second one. accounts_contact_id must
+    // also be unique per connector/plugin, so derive it from the contact ID
+    // rather than reusing a fixed GUID across multiple fixtures in one test.
+    $existingContact = $this->callAPISuccess('AccountContact', 'get', [
+      'contact_id' => $contactID,
+      'connector_id' => 0,
+      'plugin' => 'xero',
+    ]);
+    $accountContactParams = [
+      'contact_id' => $contactID,
+      'accounts_contact_id' => sprintf('11111111-1111-1111-1111-%012d', $contactID),
+      'plugin' => 'xero',
+      'connector_id' => 0,
+    ];
+    if ($existingContact['count'] > 0) {
+      $accountContactParams['id'] = reset($existingContact['values'])['id'];
+    }
+    $this->callAPISuccess('AccountContact', 'create', $accountContactParams);
+    $contribution = $this->callAPISuccess('Contribution', 'create', [
+      'contact_id' => $contactID,
+      'financial_type_id' => 1,
+      'total_amount' => 50,
+      'receive_date' => '2024-03-15',
+      'contribution_status_id' => 'Completed',
+      'source' => 'Test',
+    ]);
+    // accountsync's own hook_civicrm_post may have already auto-created an
+    // AccountInvoice row for this contribution (depending on this site's
+    // account_sync settings) - update that row rather than colliding with
+    // the UI_invoice_id_plugin unique index by inserting a second one.
+    $existing = $this->callAPISuccess('AccountInvoice', 'get', [
+      'contribution_id' => $contribution['id'],
+      'connector_id' => 0,
+      'plugin' => 'xero',
+    ]);
+    $params = [
+      'contribution_id' => $contribution['id'],
+      'plugin' => 'xero',
+      'connector_id' => 0,
+      'accounts_needs_update' => 1,
+    ];
+    if ($existing['count'] > 0) {
+      $params['id'] = reset($existing['values'])['id'];
+    }
+    $accountInvoice = $this->callAPISuccess('AccountInvoice', 'create', $params);
+    return [
+      'contribution_id' => $contribution['id'],
+      'account_invoice_id' => $accountInvoice['id'],
+    ];
+  }
+
+  public function testPushSuccessUpdatesAccountInvoice(): void {
+    $fixture = $this->createQueuedAccountInvoice();
+    $invoice = new InvoicePushTestable([]);
+    $invoice->pushToXeroQueue[] = [
+      'result' => [
+        'Invoices' => [
+          'Invoice' => [
+            'InvoiceID' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+            'UpdatedDateUTC' => '2024-03-15 10:00:00',
+            'Status' => 'AUTHORISED',
+          ],
+        ],
+      ],
+    ];
+
+    $count = $invoice->push(['connector_id' => 0], 10);
+
+    $this->assertEquals(1, $count);
+    $this->assertCount(1, $invoice->pushToXeroCalls);
+    $saved = $this->callAPISuccessGetSingle('AccountInvoice', ['id' => $fixture['account_invoice_id']]);
+    $this->assertEquals('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', $saved['accounts_invoice_id']);
+    $this->assertEquals(0, $saved['accounts_needs_update']);
+  }
+
+  public function testPushWithNoQueuedInvoicesReturnsZeroWithoutCallingPushToXero(): void {
+    $invoice = new InvoicePushTestable([]);
+    $count = $invoice->push(['connector_id' => 0], 10);
+    $this->assertEquals(0, $count);
+    $this->assertCount(0, $invoice->pushToXeroCalls);
+  }
+
+  public function testPushRecordsErrorAndContinuesWhenPushToXeroThrowsCoreException(): void {
+    $fixtureA = $this->createQueuedAccountInvoice();
+    $fixtureB = $this->createQueuedAccountInvoice();
+    $invoice = new InvoicePushTestable([]);
+    // getAccountInvoicesToPush() orders by error_data (nulls first), so
+    // insertion order among two fresh (error_data IS NULL) rows isn't
+    // guaranteed - queue the same failure/success pair regardless of which
+    // fixture is processed first, and assert on totals instead of identity.
+    $invoice->pushToXeroQueue[] = ['throw' => new CRM_Core_Exception('Xero rejected the invoice')];
+    $invoice->pushToXeroQueue[] = [
+      'result' => [
+        'Invoices' => [
+          'Invoice' => [
+            'InvoiceID' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+            'UpdatedDateUTC' => '2024-03-15 10:00:00',
+            'Status' => 'AUTHORISED',
+          ],
+        ],
+      ],
+    ];
+
+    try {
+      $invoice->push(['connector_id' => 0], 10);
+      $this->fail('Expected push() to throw because one record failed');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertStringContainsString('Not all records were saved', $e->getMessage());
+    }
+
+    // Both records were attempted (the failure didn't abort the loop).
+    $this->assertCount(2, $invoice->pushToXeroCalls);
+    $accountInvoices = $this->callAPISuccess('AccountInvoice', 'get', [
+      'id' => ['IN' => [$fixtureA['account_invoice_id'], $fixtureB['account_invoice_id']]],
+    ])['values'];
+    $withError = array_filter($accountInvoices, fn($r) => !empty($r['error_data'] ?? NULL));
+    $withoutError = array_filter($accountInvoices, fn($r) => empty($r['error_data'] ?? NULL));
+    $this->assertCount(1, $withError);
+    $this->assertCount(1, $withoutError);
+    $failed = reset($withError);
+    $this->assertStringContainsString('Xero rejected the invoice', $failed['error_data']);
+    // Still queued for retry - a generic CRM_Core_Exception isn't a permanent failure.
+    $this->assertEquals(1, $failed['accounts_needs_update']);
+  }
+
+  public function testPushAbortsRemainingRecordsAndSetsRateLimitOnThrottle(): void {
+    $this->createQueuedAccountInvoice();
+    $this->createQueuedAccountInvoice();
+    $invoice = new InvoicePushTestable([]);
+    $invoice->pushToXeroQueue[] = ['throw' => new CRM_Civixero_Exception_XeroThrottle('Rate limited', 429, NULL, time() + 3600)];
+
+    try {
+      $invoice->push(['connector_id' => 0], 10);
+      $this->fail('Expected push() to throw because Xero throttled the request');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertStringContainsString('Push aborted due to throttling by Xero', $e->getMessage());
+    }
+
+    // The throttle exception aborts the whole loop - the second record is
+    // never attempted.
+    $this->assertCount(1, $invoice->pushToXeroCalls);
+    $this->assertNotEmpty(Civi::settings()->get('xero_oauth_rate_exceeded'));
+  }
+
+}

--- a/tests/phpunit/InvoiceResponseHandlingTest.php
+++ b/tests/phpunit/InvoiceResponseHandlingTest.php
@@ -1,0 +1,228 @@
+<?php
+
+use Civi\InvoiceResponseHandlingTestable;
+use Civi\MockConnector;
+use Civi\Test\Api3TestTrait;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterization tests for savePushResponse()/validateResponse() -
+ * the seam that stays load-bearing across the Xero-SDK migration.
+ *
+ * pushToXero() is being swapped from the legacy Xero package to the
+ * xeroapi/xero-php-oauth2 SDK, but savePushResponse()/validateResponse()
+ * are unchanged by that migration - they consume whatever pushToXero()
+ * returns. These tests pin down that they correctly interpret the legacy
+ * response shapes pushToXero() has always produced.
+ *
+ * @group headless
+ */
+class InvoiceResponseHandlingTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  use Api3TestTrait;
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->install('org.civicrm.search_kit')
+      ->install('nz.co.fuzion.accountsync')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp(): void {
+    Civi::$statics['civixero_connector'] = new MockConnector();
+    CRM_Civixero_Base::resetApiRateLimitExceeded();
+    parent::setUp();
+  }
+
+  public function tearDown(): void {
+    CRM_Civixero_Base::resetApiRateLimitExceeded();
+    parent::tearDown();
+  }
+
+  private function getInvoice(): InvoiceResponseHandlingTestable {
+    return new InvoiceResponseHandlingTestable([]);
+  }
+
+  private function createBaseAccountInvoiceRecord(): array {
+    $result = $this->callAPISuccess('AccountInvoice', 'create', [
+      'plugin' => 'xero',
+      'connector_id' => 0,
+      'accounts_needs_update' => 1,
+    ]);
+    return reset($result['values']);
+  }
+
+  private function getAccountInvoice(int $id): array {
+    return $this->callAPISuccess('AccountInvoice', 'getsingle', ['id' => $id]);
+  }
+
+  public function testSavePushResponseFalseResultMarksNoUpdateNeededWithoutError(): void {
+    $record = $this->createBaseAccountInvoiceRecord();
+
+    $errors = $this->getInvoice()->callSavePushResponse(FALSE, $record);
+
+    $this->assertEquals([], $errors);
+    $saved = $this->getAccountInvoice($record['id']);
+    $this->assertEquals(0, $saved['accounts_needs_update']);
+  }
+
+  public function testSavePushResponseInvoiceSuccessShapeUpdatesRecord(): void {
+    $record = $this->createBaseAccountInvoiceRecord();
+    $result = [
+      'Invoices' => [
+        'Invoice' => [
+          'InvoiceID' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          'UpdatedDateUTC' => '2024-03-15 10:00:00',
+          'Status' => 'AUTHORISED',
+          'Contact' => ['ContactID' => 'should-be-stripped'],
+          'LineItems' => ['LineItem' => ['should-be-stripped']],
+        ],
+      ],
+    ];
+
+    $errors = $this->getInvoice()->callSavePushResponse($result, $record);
+
+    $this->assertEquals([], $errors);
+    $saved = $this->getAccountInvoice($record['id']);
+    $this->assertEquals('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', $saved['accounts_invoice_id']);
+    $this->assertEquals('2024-03-15 10:00:00', $saved['accounts_modified_date']);
+    $this->assertEquals(0, $saved['accounts_needs_update']);
+    // savePushResponse() sets error_data to the *string* 'null' - but API3's
+    // "magic null string" convention (any field value literally 'null' means
+    // "set this to SQL NULL") means it's actually stored/returned as NULL,
+    // not the string 'null'.
+    $this->assertArrayNotHasKey('error_data', $saved);
+    // AUTHORISED maps to the 'pending' accounts_status_id.
+    $accountsData = json_decode($saved['accounts_data'], TRUE);
+    $this->assertArrayNotHasKey('Contact', $accountsData);
+    $this->assertArrayNotHasKey('LineItems', $accountsData);
+  }
+
+  public function testSavePushResponseBankTransactionSuccessShapeUpdatesRecord(): void {
+    $record = $this->createBaseAccountInvoiceRecord();
+    $result = [
+      'BankTransactions' => [
+        'BankTransaction' => [
+          'BankTransactionID' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          'UpdatedDateUTC' => '2024-03-15 10:00:00',
+          'Status' => 'AUTHORISED',
+        ],
+      ],
+    ];
+
+    $errors = $this->getInvoice()->callSavePushResponse($result, $record);
+
+    $this->assertEquals([], $errors);
+    $saved = $this->getAccountInvoice($record['id']);
+    $this->assertEquals('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', $saved['accounts_invoice_id']);
+    $this->assertEquals('2024-03-15 10:00:00', $saved['accounts_modified_date']);
+    $this->assertEquals(0, $saved['accounts_needs_update']);
+  }
+
+  public function testSavePushResponseLegacyValidationErrorShapeIsRecordedAsError(): void {
+    $record = $this->createBaseAccountInvoiceRecord();
+    $result = [
+      'Elements' => [
+        'DataContractBase' => [
+          'ValidationErrors' => [
+            ['Message' => 'Something else is wrong'],
+          ],
+        ],
+      ],
+    ];
+
+    $errors = $this->getInvoice()->callSavePushResponse($result, $record);
+
+    $this->assertEquals(['Something else is wrong'], $errors);
+    $saved = $this->getAccountInvoice($record['id']);
+    // Not a "not update candidate" message, so still queued for retry.
+    $this->assertEquals(1, $saved['accounts_needs_update']);
+    $this->assertEquals(json_encode($errors), $saved['error_data']);
+  }
+
+  public function testSavePushResponseNotUpdateCandidateClearsNeedsUpdateFlag(): void {
+    $record = $this->createBaseAccountInvoiceRecord();
+    $result = [
+      'Elements' => [
+        'DataContractBase' => [
+          'ValidationErrors' => [
+            ['Message' => 'Invoice not of valid status for modification'],
+          ],
+        ],
+      ],
+    ];
+
+    $this->getInvoice()->callSavePushResponse($result, $record);
+
+    $saved = $this->getAccountInvoice($record['id']);
+    // We can't ever update this one in Xero, so stop retrying it.
+    $this->assertEquals(0, $saved['accounts_needs_update']);
+  }
+
+  public function testValidateResponseAccountCodeMandatoryShortCircuits(): void {
+    $response = [
+      'Elements' => [
+        'DataContractBase' => [
+          'ValidationErrors' => [
+            [
+              ['Message' => 'Account code must be specified'],
+            ],
+          ],
+        ],
+      ],
+    ];
+    $errors = $this->getInvoice()->callValidateResponse($response);
+    $this->assertEquals(['You need to set up the account code'], $errors);
+  }
+
+  public function testValidateResponseSignatureInvalidThrows(): void {
+    $this->expectException(CRM_Core_Exception::class);
+    $this->expectExceptionMessage('Invalid signature - your key may be invalid');
+    $this->getInvoice()->callValidateResponse('oauth_problem=signature_invalid');
+  }
+
+  /**
+   * Characterizes actual (not intended) behaviour: validateResponse() strips
+   * the 'oauth_problem=' prefix into $problem, then compares $problem against
+   * the *unstripped* string 'oauth_problem=token_rejected' - a comparison
+   * that can never be true. So a token_rejected response falls through to
+   * the generic throttle branch instead of throwing 'Invalid credentials'.
+   * This is a pre-existing bug independent of the SDK migration - flagging
+   * it here so it isn't accidentally "fixed" as a side effect of swapping
+   * pushToXero(), which would silently change this test's expected outcome.
+   */
+  public function testValidateResponseTokenRejectedActuallyFallsThroughToThrottle(): void {
+    $this->expectException(CRM_Civixero_Exception_XeroThrottle::class);
+    $this->getInvoice()->callValidateResponse('oauth_problem=token_rejected');
+  }
+
+  public function testValidateResponseUnknownOauthProblemThrowsThrottleAndSetsRateLimit(): void {
+    $this->assertFalse((bool) Civi::settings()->get('xero_oauth_rate_exceeded'));
+
+    try {
+      $this->getInvoice()->callValidateResponse('oauth_problem=rate_limit_exceeded');
+      $this->fail('Expected a CRM_Civixero_Exception_XeroThrottle to be thrown');
+    }
+    catch (CRM_Civixero_Exception_XeroThrottle $e) {
+      $this->assertEquals('rate_limit_exceeded', $e->getMessage());
+    }
+
+    $this->assertNotEmpty(Civi::settings()->get('xero_oauth_rate_exceeded'));
+  }
+
+  public function testIsNotUpdateCandidateMatchesSubstring(): void {
+    $invoice = $this->getInvoice();
+    $this->assertTrue($invoice->callIsNotUpdateCandidate([
+      'Some prefix: This document cannot be edited as it has a payment or credit note allocated to it.',
+    ]));
+    $this->assertFalse($invoice->callIsNotUpdateCandidate([
+      'Some unrelated error',
+    ]));
+  }
+
+}

--- a/tests/phpunit/InvoiceResponseHandlingTest.php
+++ b/tests/phpunit/InvoiceResponseHandlingTest.php
@@ -145,6 +145,28 @@ class InvoiceResponseHandlingTest extends TestCase implements HeadlessInterface,
     $this->assertEquals(json_encode($errors), $saved['error_data']);
   }
 
+  /**
+   * pushViaApi() (added by PR #215, the Xero-SDK migration) returns
+   * ['ValidationErrors' => [...]] on a Xero validation failure - a
+   * top-level key distinct from the legacy package's nested
+   * Elements.DataContractBase.ValidationErrors shape. Without the fix in
+   * validateResponse(), this fell through to the "success" branch and
+   * crashed reading $result['Invoices']['Invoice']['UpdatedDateUTC'] from a
+   * response that doesn't have it. See InvoiceSdkPushTest for pushViaApi()
+   * actually producing this shape from a mocked Xero response.
+   */
+  public function testSavePushResponseRecognisesNewSdkTopLevelValidationErrorsShape(): void {
+    $record = $this->createBaseAccountInvoiceRecord();
+    $result = ['ValidationErrors' => ['Account code must be specified']];
+
+    $errors = $this->getInvoice()->callSavePushResponse($result, $record);
+
+    $this->assertEquals(['Account code must be specified'], $errors);
+    $saved = $this->getAccountInvoice($record['id']);
+    $this->assertEquals(1, $saved['accounts_needs_update']);
+    $this->assertEquals(json_encode($errors), $saved['error_data']);
+  }
+
   public function testSavePushResponseNotUpdateCandidateClearsNeedsUpdateFlag(): void {
     $record = $this->createBaseAccountInvoiceRecord();
     $result = [

--- a/tests/phpunit/InvoiceSdkPushTest.php
+++ b/tests/phpunit/InvoiceSdkPushTest.php
@@ -1,0 +1,190 @@
+<?php
+
+use Civi\InvoiceSdkPushTestable;
+use Civi\MockConnector;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\GuzzleTestTrait;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises pushViaApi() (added by civixero PR #215, the Xero-SDK migration)
+ * against the real xeroapi/xero-php-oauth2 AccountingApi with a mocked
+ * Guzzle HTTP client (Civi\Test\GuzzleTestTrait, the same pattern core uses
+ * for testing payment-gateway integrations) - so the SDK's own request
+ * building/serialization and response deserialization run for real, only
+ * the network call itself is faked.
+ *
+ * @group headless
+ */
+class InvoiceSdkPushTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  use GuzzleTestTrait;
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->install('org.civicrm.search_kit')
+      ->install('nz.co.fuzion.accountsync')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp(): void {
+    Civi::$statics['civixero_connector'] = new MockConnector();
+    parent::setUp();
+  }
+
+  private function getMappedInvoice(array $overrides = []): array {
+    return [$overrides + [
+      'Type' => 'ACCREC',
+      'Contact' => ['ContactID' => '11111111-1111-1111-1111-111111111111'],
+      'Date' => '2024-03-15',
+      'DueDate' => '2024-03-15',
+      'Status' => 'SUBMITTED',
+      'InvoiceNumber' => 'CIVI123',
+      'CurrencyCode' => 'NZD',
+      'Reference' => 'Test invoice',
+      'LineAmountTypes' => 'Inclusive',
+      'LineItems' => [
+        'LineItem' => [
+          [
+            'Description' => 'General Admission',
+            'Quantity' => 1,
+            'UnitAmount' => 50,
+            'AccountCode' => '400',
+          ],
+        ],
+      ],
+    ]];
+  }
+
+  private function getInvoiceWithMockClient(): InvoiceSdkPushTestable {
+    $this->setUpClientWithHistoryContainer();
+    $invoice = new InvoiceSdkPushTestable([]);
+    $invoice->mockClient = $this->getGuzzleClient();
+    return $invoice;
+  }
+
+  public function testPushToXeroSuccessReturnsLegacyShapedInvoiceResult(): void {
+    $this->createMockHandler([
+      json_encode([
+        'Invoices' => [
+          [
+            'InvoiceID' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+            'Type' => 'ACCREC',
+            'Status' => 'AUTHORISED',
+            'UpdatedDateUTC' => '2024-03-15T10:00:00',
+            'InvoiceNumber' => 'CIVI123',
+          ],
+        ],
+      ]),
+    ]);
+    $invoice = $this->getInvoiceWithMockClient();
+
+    $result = $invoice->callPushToXero($this->getMappedInvoice(), 0);
+
+    $this->assertEquals(
+      'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      $result['Invoices']['Invoice']['InvoiceID']
+    );
+    $this->assertEquals('AUTHORISED', $result['Invoices']['Invoice']['Status']);
+    $this->assertEquals('2024-03-15 10:00:00', $result['Invoices']['Invoice']['UpdatedDateUTC']);
+  }
+
+  public function testPushToXeroSendsIdempotencyKeyUnderXeroLimit(): void {
+    $this->createMockHandler([
+      json_encode([
+        'Invoices' => [
+          ['InvoiceID' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', 'Status' => 'AUTHORISED', 'UpdatedDateUTC' => '2024-03-15T10:00:00'],
+        ],
+      ]),
+    ]);
+    $invoice = $this->getInvoiceWithMockClient();
+
+    $invoice->callPushToXero($this->getMappedInvoice(), 0);
+
+    $headers = $this->getRequestHeaders();
+    $this->assertCount(1, $headers);
+    $this->assertArrayHasKey('Idempotency-Key', $headers[0]);
+    $key = $headers[0]['Idempotency-Key'][0];
+    $this->assertLessThanOrEqual(128, strlen($key));
+    $this->assertStringStartsWith('civixero-invoice-CIVI123-', $key);
+  }
+
+  public function testPushToXeroRejectsMalformedStoredInvoiceIdBeforeCallingXero(): void {
+    $invoice = $this->getInvoiceWithMockClient();
+    // No response queued on the mock handler - if this reaches the HTTP
+    // layer at all, the test will fail with a MockHandler "no more
+    // responses" error rather than the expected CRM_Core_Exception,
+    // proving the GUID check happens client-side before any request goes out.
+    $mapped = $this->getMappedInvoice(['InvoiceID' => 'not-a-guid']);
+
+    $this->expectException(CRM_Core_Exception::class);
+    $this->expectExceptionMessageMatches('/not a valid Xero ID/');
+    $invoice->callPushToXero($mapped, 0);
+  }
+
+  /**
+   * This is the seam PR #215 actually changes: pushViaApi() (unlike the
+   * legacy pushToXero()) returns a top-level 'ValidationErrors' key on a
+   * Xero validation failure - see InvoiceResponseHandlingTest for whether
+   * savePushResponse()/validateResponse() correctly recognise that shape.
+   */
+  public function testPushToXeroValidationFailureReturnsTopLevelValidationErrorsShape(): void {
+    $this->createMockHandler([
+      json_encode([
+        'Invoices' => [
+          [
+            'Type' => 'ACCREC',
+            'Status' => 'DRAFT',
+            'ValidationErrors' => [
+              ['Message' => 'Account code must be specified'],
+            ],
+          ],
+        ],
+      ]),
+    ]);
+    $invoice = $this->getInvoiceWithMockClient();
+
+    $result = $invoice->callPushToXero($this->getMappedInvoice(), 0);
+
+    $this->assertEquals(['ValidationErrors' => ['Account code must be specified']], $result);
+  }
+
+  /**
+   * Characterizes a gap introduced by PR #215: pushToXero()'s catch blocks
+   * catch \XeroAPI\XeroPHP\ApiException (the new SDK's HTTP-error exception,
+   * e.g. for a 429 rate-limit response) and translate a 429 into
+   * CRM_Civixero_Exception_XeroThrottle, same as the legacy path did via
+   * XeroThrottleException - so push()'s throttle-abort-and-backoff handling
+   * (see InvoicePushTest::testPushAbortsRemainingRecordsAndSetsRateLimitOnThrottle)
+   * keeps working once pushToXero() is switched to the SDK.
+   */
+  public function testPushToXeroTranslatesNewSdk429ResponseToThrottleException(): void {
+    $this->createMockHandler([]);
+    // createMockHandler() only builds 200s - queue a 429 directly.
+    $this->getMockHandler()->append(new \GuzzleHttp\Psr7\Response(429, ['Retry-After' => '120'], json_encode(['Message' => 'Rate limit exceeded'])));
+    $invoice = $this->getInvoiceWithMockClient();
+
+    try {
+      $invoice->callPushToXero($this->getMappedInvoice(), 0);
+      $this->fail('Expected a CRM_Civixero_Exception_XeroThrottle to be thrown');
+    }
+    catch (CRM_Civixero_Exception_XeroThrottle $e) {
+      $this->assertGreaterThan(time(), $e->getRetryAfter());
+    }
+  }
+
+  public function testPushToXeroTranslatesOtherNewSdkApiExceptionsToCoreException(): void {
+    $this->createMockHandler([]);
+    $this->getMockHandler()->append(new \GuzzleHttp\Psr7\Response(500, [], json_encode(['Message' => 'Internal error'])));
+    $invoice = $this->getInvoiceWithMockClient();
+
+    $this->expectException(CRM_Core_Exception::class);
+    $this->expectExceptionMessageMatches('/Synchronization error/');
+    $invoice->callPushToXero($this->getMappedInvoice(), 0);
+  }
+
+}


### PR DESCRIPTION
Adds phpunit tests around Invoice/BankTransaction push() (mapping, response handling, push() orchestration, and SDK-level tests against a mocked Guzzle client) to validate #215 doesn't change observable behaviour.

Also fixes 3 bugs the tests surfaced in #215 as written:
- `validateResponse()` didn't recognise `pushViaApi()`'s new top-level `ValidationErrors` shape, so a Xero validation failure was misread as success.
- `pushToXero()` only caught the legacy `XeroException`/`XeroThrottleException`, not the SDK's `ApiException` - a 429 broke throttle handling.
- `pushViaApi()` was `private` in both classes; since private methods aren't virtual in PHP, `BankTransaction`'s override never ran and every bank-transaction push crashed. This one's a merge-blocker on its own.

Left as a draft since it's built on top of #215 rather than master - happy to rebase once that lands, or split differently if you'd prefer.