### PR TITLE
Add Setting To Use Invoice Number From Contribution

### DIFF
--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -205,6 +205,20 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
         ->addWhere('accounts_invoice_id', '=', $xeroInvoice['invoice_id'])
         ->execute()
         ->first();
+
+      $matchedByInvoiceNumber = FALSE;
+      if (empty($accountInvoice) || empty($accountInvoice['contribution_id'])) {
+        $matchResult = $this->getContributionIDFromInvoiceNumberMatch($xeroInvoice, $connectorID);
+        if ($matchResult) {
+          // A reliable match takes precedence over the prefix-derived one.
+          $matchedByInvoiceNumber = TRUE;
+          $accountInvoiceParams['contribution_id'] = $matchResult;
+        }
+        elseif ($matchResult === FALSE) {
+          unset($accountInvoiceParams['contribution_id']);
+        }
+        // NULL: no candidate (or setting disabled) - keep any prefix-derived ID.
+      }
       try {
         if (empty($accountInvoice)) {
           // Invoice is in Xero but (accounts_invoice_id) does not exist in account_invoice table
@@ -212,12 +226,37 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
           //   derived from Xero invoice ID without prefix.
           // So we can't use contribution ID - remove it, and then we'll record a new entry in account_invoice with Xero invoice.
           // This could be manually reconciled by adding a contribution ID.
-          // Create a new AccountInvoice record
-          unset($accountInvoiceParams['contribution_id']);
-          $newAccountInvoice = AccountInvoice::create(FALSE)
-            ->setValues($accountInvoiceParams)
-            ->execute()
-            ->first();
+          // The exception is an exact match on the contribution's invoice_number
+          // (guarded by uniqueness/amount checks) which is reliable enough to link.
+          if (!$matchedByInvoiceNumber) {
+            unset($accountInvoiceParams['contribution_id']);
+          }
+          $pendingAccountInvoice = NULL;
+          if ($matchedByInvoiceNumber) {
+            $pendingAccountInvoice = AccountInvoice::get(FALSE)
+              ->addWhere('plugin', '=', $this->_plugin)
+              ->addWhere('connector_id', '=', $connectorID)
+              ->addWhere('contribution_id', '=', $accountInvoiceParams['contribution_id'])
+              ->addWhere('accounts_invoice_id', 'IS NULL')
+              ->execute()
+              ->first();
+          }
+          if (!empty($pendingAccountInvoice)) {
+            $adoptParams = $accountInvoiceParams;
+            unset($adoptParams['accounts_needs_update']);
+            $newAccountInvoice = AccountInvoice::update(FALSE)
+              ->setValues($adoptParams)
+              ->addWhere('id', '=', $pendingAccountInvoice['id'])
+              ->execute()
+              ->first();
+          }
+          else {
+            // Create a new AccountInvoice record
+            $newAccountInvoice = AccountInvoice::create(FALSE)
+              ->setValues($accountInvoiceParams)
+              ->execute()
+              ->first();
+          }
           $ids[] = $newAccountInvoice['id'];
         }
         else {
@@ -227,29 +266,39 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
             'accounts_status_id',
             'accounts_needs_update',
           ];
+          // Every time we do an "update" last_sync_date is updated which triggers an entry in log_civicrm_account_contact.
+          // So check if anything actually changed before updating.
+          $somethingChanged = FALSE;
           foreach ($modifiedFieldKeys as $key) {
-            // Every time we do an "update" last_sync_date is updated which triggers an entry in log_civicrm_account_contact.
-            // So check if anything actually changed before updating.
             if ($accountInvoiceParams[$key] !== $accountInvoice[$key]) {
-              // Something changed, update AccountInvoice in DB
-              if (!empty($accountInvoice['contribution_id'])) {
-                // If the accountInvoice already has a contribution ID don't try to overwrite it with the one we derived from InvoiceNumber.
-                // Probably we manually reconciled it at some point.
-                unset($accountInvoiceParams['contribution_id']);
-              }
-              if (isset($accountInvoiceParams['contribution_id']) && empty(Contribution::get(FALSE)->addWhere('id', '=', $accountInvoiceParams['contribution_id'])->execute()->first())) {
-                // This happens if we deleted the contribution in CiviCRM
-                $accountInvoiceParams['error_data'] = json_encode(['error' => "ContributionID {$accountInvoiceParams['contribution_id']} not found in CiviCRM. If you deleted it you can mark this as resolved."]);
-                unset($accountInvoiceParams['contribution_id']);
-              }
-              $newAccountInvoice = AccountInvoice::update(FALSE)
-                ->setValues($accountInvoiceParams)
-                ->addWhere('id', '=', $accountInvoice['id'])
-                ->execute()
-                ->first();
-              $ids[] = $newAccountInvoice['id'];
+              $somethingChanged = TRUE;
               break;
             }
+          }
+          // A reliable invoice-number match that back-fills a missing
+          // contribution link is a change in its own right - otherwise
+          // existing unlinked rows are never reconnected unless a tracked
+          // field happens to have changed in Xero since the last pull.
+          if (!$somethingChanged && $matchedByInvoiceNumber && empty($accountInvoice['contribution_id']) && isset($accountInvoiceParams['contribution_id'])) {
+            $somethingChanged = TRUE;
+          }
+          if ($somethingChanged) {
+            if (!empty($accountInvoice['contribution_id'])) {
+              // If the accountInvoice already has a contribution ID don't try to overwrite it with the one we derived from InvoiceNumber.
+              // Probably we manually reconciled it at some point.
+              unset($accountInvoiceParams['contribution_id']);
+            }
+            if (isset($accountInvoiceParams['contribution_id']) && empty(Contribution::get(FALSE)->addWhere('id', '=', $accountInvoiceParams['contribution_id'])->execute()->first())) {
+              // This happens if we deleted the contribution in CiviCRM
+              $accountInvoiceParams['error_data'] = json_encode(['error' => "ContributionID {$accountInvoiceParams['contribution_id']} not found in CiviCRM. If you deleted it you can mark this as resolved."]);
+              unset($accountInvoiceParams['contribution_id']);
+            }
+            $newAccountInvoice = AccountInvoice::update(FALSE)
+              ->setValues($accountInvoiceParams)
+              ->addWhere('id', '=', $accountInvoice['id'])
+              ->execute()
+              ->first();
+            $ids[] = $newAccountInvoice['id'];
           }
         }
         if ($createContributionInCiviCRM) {
@@ -408,10 +457,6 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
     // Get default Invoice status
     $status = $this->settings->get('xero_default_invoice_status');
 
-    $prefix = $this->settings->get('xero_invoice_number_prefix');
-    if (empty($prefix)) {
-      $prefix = '';
-    }
     $new_invoice = [
       'Type' => ($total_amount > 0) ? 'ACCREC' : 'ACCPAY',
       'Contact' => [
@@ -420,7 +465,7 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
       'Date' => substr($invoiceData['receive_date'], 0, 10),
       'DueDate' => substr($invoiceData['receive_date'], 0, 10),
       'Status' => $status,
-      'InvoiceNumber' => $prefix . $invoiceData['id'],
+      'InvoiceNumber' => $this->getInvoiceNumber((int) ($invoiceData['id'] ?? NULL), $invoiceData['invoice_number'] ?? NULL),
       'CurrencyCode' => $invoiceData['currency'],
       'Reference' => $invoiceData['display_name'] . ' ' . $invoiceData['contribution_source'],
       'LineAmountTypes' => $line_amount_types,
@@ -457,11 +502,10 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
    * @return array
    */
   protected function mapCancelled(int $contributionID, ?string $xeroInvoiceUUID): array {
-    $prefix = $this->settings->get('xero_invoice_number_prefix') ?: '';
     return [
       'Invoice' => [
         'InvoiceID' => $xeroInvoiceUUID,
-        'InvoiceNumber' => $prefix . $contributionID,
+        'InvoiceNumber' => $this->getInvoiceNumber($contributionID),
         'Type' => 'ACCREC',
         'Reference' => 'Cancelled',
         'Date' => date('Y-m-d'),
@@ -478,6 +522,119 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
         ],
       ],
     ];
+  }
+
+  /**
+   * Get the invoice number to send to Xero for a contribution.
+   *
+   * @param int $contributionID
+   * @param string|null $contributionInvoiceNumber
+   *   The contribution's invoice_number if already known by the caller.
+   *   Pass NULL to have it looked up when required.
+   *
+   * @return string
+   */
+  protected function getInvoiceNumber(int $contributionID, ?string $contributionInvoiceNumber = NULL): string {
+    if ($this->settings->get('xero_use_contribution_invoice_number')) {
+      if ($contributionInvoiceNumber === NULL) {
+        try {
+          $contributionInvoiceNumber = (string) (Contribution::get(FALSE)
+            ->addSelect('invoice_number')
+            ->addWhere('id', '=', $contributionID)
+            ->execute()
+            ->first()['invoice_number'] ?? '');
+        }
+        catch (Exception $e) {
+          \Civi::log('civixero')->warning('getInvoiceNumber: could not load invoice_number for contribution ' . $contributionID . ': ' . $e->getMessage());
+          $contributionInvoiceNumber = '';
+        }
+      }
+      // Explicit check rather than empty(): the string '0' is a valid
+      // (if unlikely) invoice number and empty('0') is TRUE.
+      if ($contributionInvoiceNumber !== NULL && $contributionInvoiceNumber !== '') {
+        return (string) $contributionInvoiceNumber;
+      }
+    }
+    $prefix = $this->settings->get('xero_invoice_number_prefix') ?: '';
+
+    return $prefix . $contributionID;
+  }
+
+  /**
+   * Try to match a pulled Xero invoice to a contribution by invoice number.
+   *
+   * @param array $xeroInvoice
+   *   Invoice data pulled from Xero (needs invoice_number, invoice_id, total).
+   * @param int $connectorID
+   *   ID of the connector (0 if nz.co.fuzion.connectors is not installed).
+   *
+   * @return int|false|null
+   *   - int: the matched contribution ID.
+   *   - NULL: no candidate (or setting disabled) - the caller may fall back
+   *     to other matching strategies.
+   *   - FALSE: a candidate was found but refused as unsafe (duplicate
+   *     invoice_number, linked to a different Xero invoice, or total
+   *     mismatch) - the caller must NOT fall back to weaker matching.
+   */
+  protected function getContributionIDFromInvoiceNumberMatch(array $xeroInvoice, int $connectorID) {
+    $xeroInvoiceNumber = $xeroInvoice['invoice_number'] ?? NULL;
+    // Explicit check rather than empty(): the string '0' is a valid
+    // (if unlikely) invoice number and empty('0') is TRUE.
+    if (!$this->getSetting('xero_use_contribution_invoice_number') || $xeroInvoiceNumber === NULL || $xeroInvoiceNumber === '') {
+      return NULL;
+    }
+
+    $contributions = Contribution::get(FALSE)
+      ->addSelect('id', 'total_amount')
+      ->addWhere('invoice_number', '=', $xeroInvoice['invoice_number'])
+      ->addWhere('is_test', '=', FALSE)
+      ->addWhere('is_template', '=', FALSE)
+      ->setLimit(2)
+      ->execute();
+    if (count($contributions) === 0) {
+      // No candidate - the caller may fall back to other matching strategies.
+      return NULL;
+    }
+    if (count($contributions) > 1) {
+      \Civi::log('civixero')->warning('Invoice pull: multiple contributions share invoice_number {invoiceNumber} - not linking Xero invoice {xeroInvoiceID}.', [
+        'invoiceNumber' => $xeroInvoice['invoice_number'],
+        'xeroInvoiceID' => $xeroInvoice['invoice_id'] ?? '',
+      ]);
+      return FALSE;
+    }
+    $contribution = $contributions->first();
+
+    // Don't steal a contribution that is already linked to a different Xero invoice.
+    $existingLink = AccountInvoice::get(FALSE)
+      ->addSelect('id', 'accounts_invoice_id')
+      ->addWhere('plugin', '=', $this->_plugin)
+      ->addWhere('connector_id', '=', $connectorID)
+      ->addWhere('contribution_id', '=', $contribution['id'])
+      ->execute()
+      ->first();
+    if (!empty($existingLink['accounts_invoice_id']) && $existingLink['accounts_invoice_id'] !== ($xeroInvoice['invoice_id'] ?? '')) {
+      \Civi::log('civixero')->warning('Invoice pull: contribution {contributionID} (invoice_number {invoiceNumber}) is already linked to Xero invoice {existing} - not linking Xero invoice {xeroInvoiceID}.', [
+        'contributionID' => $contribution['id'],
+        'invoiceNumber' => $xeroInvoice['invoice_number'],
+        'existing' => $existingLink['accounts_invoice_id'],
+        'xeroInvoiceID' => $xeroInvoice['invoice_id'] ?? '',
+      ]);
+      return FALSE;
+    }
+
+    // Sanity check: totals should match.
+    if (isset($xeroInvoice['total']) && isset($contribution['total_amount'])
+      && abs(abs((float) $xeroInvoice['total']) - abs((float) $contribution['total_amount'])) > 0.011) {
+      \Civi::log('civixero')->warning('Invoice pull: Xero invoice {xeroInvoiceID} total {xeroTotal} does not match contribution {contributionID} total {civiTotal} - not linking despite invoice_number match.', [
+        'xeroInvoiceID' => $xeroInvoice['invoice_id'] ?? '',
+        'xeroTotal' => $xeroInvoice['total'],
+        'contributionID' => $contribution['id'],
+        'civiTotal' => $contribution['total_amount'],
+      ]);
+      return FALSE;
+    }
+
+    return (int) $contribution['id'];
   }
 
   /**

--- a/settings/Civixero.setting.php
+++ b/settings/Civixero.setting.php
@@ -112,6 +112,18 @@ return [
     ],
     'settings_pages' => ['xero' => ['weight' => 2]],
   ],
+  'xero_use_contribution_invoice_number' => [
+    'name' => 'xero_use_contribution_invoice_number',
+    'type' => 'Boolean',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'default' => 0,
+    'title' => E::ts('Use CiviCRM invoice number when pushing to Xero'),
+    'description' => E::ts('When enabled, if the contribution has an invoice number it will be used as the Xero invoice number. If the contribution has no invoice number (or this setting is disabled) the invoice number is generated as (prefix + contribution ID).'),
+    'help_text' => '',
+    'html_type' => 'checkbox',
+    'settings_pages' => ['xero' => ['weight' => 2]],
+  ],
   'xero_default_invoice_status' => [
     'name' => 'xero_default_invoice_status',
     'type' => 'String',

--- a/tests/phpunit/InvoiceMappingTest.php
+++ b/tests/phpunit/InvoiceMappingTest.php
@@ -36,6 +36,8 @@ class InvoiceMappingTest extends TestCase implements HeadlessInterface, HookInte
     // in from whatever this site's Contribute settings happen to be.
     Civi::settings()->set('invoice_due_date', 0);
     Civi::settings()->set('invoice_due_date_period', 'select');
+    // Pin to the default so tests that enable it can't leak into others.
+    Civi::settings()->set('xero_use_contribution_invoice_number', FALSE);
     parent::setUp();
   }
 
@@ -131,6 +133,30 @@ class InvoiceMappingTest extends TestCase implements HeadlessInterface, HookInte
 
     $result = $this->getInvoice()->callMapToAccounts($invoiceData, NULL);
     $this->assertEquals('Inclusive', $result[0]['LineAmountTypes']);
+  }
+
+  public function testMapToAccountsUsesContributionInvoiceNumberWhenSettingEnabled(): void {
+    Civi::settings()->set('xero_use_contribution_invoice_number', TRUE);
+    $invoiceData = $this->getBasicInvoiceData();
+    $invoiceData['invoice_number'] = 'INV-2024-0042';
+
+    $result = $this->getInvoice()->callMapToAccounts($invoiceData, NULL);
+    $this->assertEquals('INV-2024-0042', $result[0]['InvoiceNumber']);
+  }
+
+  public function testMapToAccountsIgnoresContributionInvoiceNumberWhenSettingDisabled(): void {
+    Civi::settings()->set('xero_use_contribution_invoice_number', FALSE);
+    $invoiceData = $this->getBasicInvoiceData();
+    $invoiceData['invoice_number'] = 'INV-2024-0042';
+
+    $result = $this->getInvoice()->callMapToAccounts($invoiceData, NULL);
+    $this->assertEquals('CIVI123', $result[0]['InvoiceNumber']);
+  }
+
+  public function testMapToAccountsFallsBackToPrefixWhenNoContributionInvoiceNumber(): void {
+    Civi::settings()->set('xero_use_contribution_invoice_number', TRUE);
+    $result = $this->getInvoice()->callMapToAccounts($this->getBasicInvoiceData(), NULL);
+    $this->assertEquals('CIVI123', $result[0]['InvoiceNumber']);
   }
 
   public function testMapCancelledWithoutUuid(): void {


### PR DESCRIPTION
## Overview

Adds an opt-in setting to use the CiviCRM contribution's own invoice number (`civicrm_contribution.invoice_number`) as the Xero `InvoiceNumber` when pushing invoices, instead of the generated `<prefix><contribution ID>` (e.g. `CIVI1234`). On the pull side, invoices are matched back to contributions by that same invoice number.

The setting is **disabled by default — existing behaviour is unchanged unless it is explicitly enabled.**

## Before

- **Push:** the Xero `InvoiceNumber` is always generated as `xero_invoice_number_prefix` + contribution ID (e.g. `CIVI1234`), regardless of any invoice number recorded on the contribution in CiviCRM.
- **Pull:** invoices not already linked via `civicrm_account_invoice` can only be matched to a contribution by stripping the configured prefix from the Xero `InvoiceNumber` and treating the remainder as a contribution ID. This cannot match invoices numbered any other way, and can mislink if a Xero invoice number happens to be prefix + some unrelated integer.


## After
<img width="1792" height="1120" alt="Screenshot 2026-08-12 at 2 00 21 PM" src="https://github.com/user-attachments/assets/7e609381-3860-447c-8d9f-9db97249ff12" />
A new checkbox **"Use CiviCRM invoice number when pushing to Xero"** is available at **Administer → CiviContribute → Xero Settings** (`civicrm/admin/setting/xero`), disabled by default.

**Push** — the contribution's invoice number is used only when **both** conditions are met:

1. The new setting is enabled, **and**
2. The contribution has a non-empty `invoice_number`.

If either condition fails, the invoice number is generated exactly as before (prefix + contribution ID).

**Pull** — when the setting is enabled, pulled Xero invoices that have no `AccountInvoice` record are first matched by exact `invoice_number` lookup against `civicrm_contribution`. The match is only used when it is safe:

- exactly one contribution has that invoice number,
- that contribution is not already linked to a different Xero invoice, and
- the Xero invoice total matches the contribution total.

If any guard fails (a warning is logged to the `civixero` channel), or the setting is disabled, the existing prefix-stripping logic runs unchanged as the fallback so mixed history (invoices pushed before and after enabling the setting) keeps matching.

## Technical Details

- New Boolean setting `xero_use_contribution_invoice_number` in `settings/Civixero.setting.php`, rendered on the Xero settings page next to the existing invoice number prefix setting.
- New `CRM_Civixero_Invoice::getInvoiceNumber()` helper encapsulates the push-side invoice number decision. Used by:
  - `mapToAccounts()` — normal invoice push. The `invoice_number` is already available from `AccountInvoice.getderived`, so no extra query is made.
  - `mapCancelled()` — cancellation push. The invoice number is looked up via APIv4 so the `InvoiceNumber` sent on cancellation matches the one the invoice was created with (avoids Xero renaming the invoice).
- New `CRM_Civixero_Invoice::getContributionIDFromInvoiceNumberMatch()` helper encapsulates the pull-side matching with the safety guards above. It is tried before the existing prefix inference; the prefix logic is untouched and remains the fallback.
- Because an exact, guarded invoice-number match is reliable (unlike a prefix-derived ID), it is also used to set `contribution_id` when creating a **new** `AccountInvoice` record during pull — restoring recovery-relinking for invoices whose numbers don't encode a contribution ID. Prefix-derived IDs keep the existing behaviour (discarded on create, applied only on update of unlinked records).
- If the push-side lookup fails, a warning is logged to the `civixero` channel and the generated number is used as a fallback.

## Tests

New headless tests in `tests/phpunit/InvoiceMappingTest.php`:

- Setting enabled + contribution has invoice number → contribution invoice number is used.
- Setting disabled + contribution has invoice number → generated number is used (current behaviour).
- Setting enabled + contribution has no invoice number → generated number is used (fallback).

Existing tests pass unchanged (setting defaults to disabled).