### PR TITLE
Migrate Contact push to the Xero SDK

### DIFF
--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -276,15 +276,8 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
 
         $xeroContactUUID = !empty($record['accounts_contact_id']) ? $record['accounts_contact_id'] : NULL;
         $accountsContact = $this->mapToAccounts($contact, $xeroContactUUID);
-        if ($accountsContact === FALSE) {
-          $result = FALSE;
-          $responseErrors = [];
-        }
-        else {
-          /** @noinspection PhpUndefinedMethodInspection */
-          $result = $this->getSingleton($params['connector_id'])->Contacts($accountsContact);
-          $responseErrors = $this->validateResponse($result);
-        }
+        $result = $this->pushToXero($accountsContact, $params['connector_id']);
+        $responseErrors = $result === FALSE ? [] : $this->validateResponse($result);
         if ($result === FALSE) {
           unset($record['accounts_modified_date']);
         }
@@ -369,6 +362,29 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
       throw new CRM_Core_Exception(E::ts('Not all contacts were saved') . print_r($errors, TRUE), 'incomplete', $errors);
     }
     return TRUE;
+  }
+
+  /**
+   * Push a single mapped contact to Xero.
+   *
+   * The only method the Xero-SDK migration touches - push()'s surrounding
+   * orchestration (error handling, throttle abort, DB updates) does not
+   * care which client this delegates to underneath.
+   *
+   * @param array|bool $accountsContact
+   *   Mapped contact array as produced by mapToAccounts(), or FALSE if a
+   *   hook vetoed the push.
+   * @param int $connector_id
+   *
+   * @return array|bool
+   *   FALSE if $accountsContact was FALSE, otherwise the raw Xero response.
+   */
+  protected function pushToXero($accountsContact, $connector_id) {
+    if ($accountsContact === FALSE) {
+      return FALSE;
+    }
+    /** @noinspection PhpUndefinedMethodInspection */
+    return $this->getSingleton($connector_id)->Contacts($accountsContact);
   }
 
   /**

--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -378,13 +378,136 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
    *
    * @return array|bool
    *   FALSE if $accountsContact was FALSE, otherwise the raw Xero response.
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function pushToXero($accountsContact, $connector_id) {
     if ($accountsContact === FALSE) {
       return FALSE;
     }
-    /** @noinspection PhpUndefinedMethodInspection */
-    return $this->getSingleton($connector_id)->Contacts($accountsContact);
+    try {
+      return $this->pushViaApi($accountsContact);
+    }
+    catch (\XeroAPI\XeroPHP\ApiException $e) {
+      if ($e->getCode() === 429) {
+        $retryAfterSeconds = (int) ($e->getResponseHeaders()['Retry-After'][0] ?? 0);
+        throw new CRM_Civixero_Exception_XeroThrottle($e->getMessage(), $e->getCode(), $e, $retryAfterSeconds ? (time() + $retryAfterSeconds) : NULL);
+      }
+      throw new CRM_Core_Exception(
+        'Synchronization error ' . $e->getMessage(),
+        'xero_' . $e->getCode(),
+        ['response' => $e->getResponseBody()]
+      );
+    }
+  }
+
+  /**
+   * Push a single mapped contact to Xero via the official SDK.
+   *
+   * Replaces the legacy hand-rolled client (packages/Xero/Xero.php). Mirrors
+   * Invoice::pushViaApi()/BankTransaction::pushViaApi()'s shape-preserving
+   * adapter: returns the exact legacy-shaped array
+   * (['Contacts']['Contact'][...]] or ['ValidationErrors' => [...]]) that
+   * push() already reads, so none of push()'s downstream field-extraction
+   * or dedupe logic needs to change.
+   *
+   * @param array $mapped
+   *   CamelCase-keyed contact array as produced by mapToAccounts().
+   *
+   * @return array
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function pushViaApi(array $mapped): array {
+    $xeroContact = $this->mappedArrayToXeroContact($mapped);
+
+    $contacts = new \XeroAPI\XeroPHP\Models\Accounting\Contacts();
+    $contacts->setContacts([$xeroContact]);
+
+    // summarize_errors = FALSE: per-contact validation errors come back on
+    // the contact object instead of a blanket HTTP 400.
+    $response = $this->getAccountingApiInstance()->updateOrCreateContacts(
+      $this->getTenantID(),
+      $contacts,
+      FALSE,
+      $this->generateIdempotencyKey('contact-' . ($mapped['ContactNumber'] ?? '0'), $mapped)
+    );
+
+    $returned = $response->getContacts()[0] ?? NULL;
+    if ($returned === NULL) {
+      throw new CRM_Core_Exception('Xero returned no contact from updateOrCreateContacts');
+    }
+    $validationErrors = $this->extractValidationErrors($returned);
+    if ($validationErrors !== []) {
+      return ['ValidationErrors' => $validationErrors];
+    }
+
+    $snapshot = json_decode((string) $returned, TRUE) ?: [];
+    $updated = $returned->getUpdatedDateUtcAsDate();
+    $snapshot['ContactID'] = $returned->getContactId();
+    $snapshot['UpdatedDateUTC'] = $updated ? $updated->format('Y-m-d H:i:s') : date('Y-m-d H:i:s');
+    $snapshot['Name'] = $returned->getName();
+    return ['Contacts' => ['Contact' => $snapshot]];
+  }
+
+  /**
+   * @return string[]
+   */
+  private function extractValidationErrors($model): array {
+    $messages = [];
+    foreach ($model->getValidationErrors() ?? [] as $validationError) {
+      $messages[] = $validationError->getMessage();
+    }
+    return $messages;
+  }
+
+  /**
+   * Convert a CamelCase mapped-contact array (from mapToAccounts()) to an
+   * SDK Contact model.
+   *
+   * Field lengths are clamped to Xero's documented limits so a single bad
+   * value cannot fail the whole push.
+   */
+  private function mappedArrayToXeroContact(array $mapped): \XeroAPI\XeroPHP\Models\Accounting\Contact {
+    $xeroContact = new \XeroAPI\XeroPHP\Models\Accounting\Contact();
+    if (!empty($mapped['ContactID'])) {
+      $this->assertValidXeroGuid((string) $mapped['ContactID'], 'Xero contact reference (ContactID)');
+      $xeroContact->setContactId($mapped['ContactID']);
+    }
+    $xeroContact->setName($mapped['Name']);
+    $xeroContact->setContactNumber((string) $mapped['ContactNumber']);
+    if (($mapped['FirstName'] ?? '') !== '') {
+      $xeroContact->setFirstName($mapped['FirstName']);
+    }
+    if (($mapped['LastName'] ?? '') !== '') {
+      $xeroContact->setLastName($mapped['LastName']);
+    }
+    if (($mapped['EmailAddress'] ?? '') !== '') {
+      $xeroContact->setEmailAddress($mapped['EmailAddress']);
+    }
+
+    if (!empty($mapped['Phones']['Phone']['PhoneNumber'])) {
+      $phone = new \XeroAPI\XeroPHP\Models\Accounting\Phone();
+      $phone->setPhoneType(\XeroAPI\XeroPHP\Models\Accounting\Phone::PHONE_TYPE__DEFAULT);
+      $phone->setPhoneNumber(mb_substr((string) $mapped['Phones']['Phone']['PhoneNumber'], 0, 50));
+      $xeroContact->setPhones([$phone]);
+    }
+
+    if (!empty($mapped['Addresses']['Address'][0])) {
+      $mappedAddress = $mapped['Addresses']['Address'][0];
+      $address = new \XeroAPI\XeroPHP\Models\Accounting\Address();
+      $address->setAddressType(\XeroAPI\XeroPHP\Models\Accounting\Address::ADDRESS_TYPE_POBOX);
+      $address->setAddressLine1(mb_substr((string) ($mappedAddress['AddressLine1'] ?? ''), 0, 500));
+      $address->setAddressLine2(mb_substr((string) ($mappedAddress['AddressLine2'] ?? ''), 0, 500));
+      $address->setAddressLine3(mb_substr((string) ($mappedAddress['AddressLine3'] ?? ''), 0, 500));
+      $address->setAddressLine4(mb_substr((string) ($mappedAddress['AddressLine4'] ?? ''), 0, 500));
+      $address->setCity(mb_substr((string) ($mappedAddress['City'] ?? ''), 0, 255));
+      $address->setPostalCode(mb_substr((string) ($mappedAddress['PostalCode'] ?? ''), 0, 50));
+      $address->setCountry(mb_substr((string) ($mappedAddress['Country'] ?? ''), 0, 50));
+      $address->setRegion(mb_substr((string) ($mappedAddress['Region'] ?? ''), 0, 255));
+      $xeroContact->setAddresses([$address]);
+    }
+    return $xeroContact;
   }
 
   /**

--- a/tests/phpunit/Civi/ContactMappingTestable.php
+++ b/tests/phpunit/Civi/ContactMappingTestable.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Civi;
+
+/**
+ * Exposes CRM_Civixero_Contact's protected mapToAccounts() for direct
+ * testing.
+ *
+ * Lives outside any *Test.php file (like MockConnector) so PHPUnit's eager
+ * file-based test discovery doesn't include_once it - and thus resolve its
+ * `extends` clause - before CiviCRM's headless install has registered the
+ * civixero extension's autoloading.
+ */
+class ContactMappingTestable extends \CRM_Civixero_Contact {
+
+  /**
+   * @return array|bool
+   */
+  public function callMapToAccounts(array $contact, ?string $xeroContactUUID) {
+    return $this->mapToAccounts($contact, $xeroContactUUID);
+  }
+
+}

--- a/tests/phpunit/Civi/ContactPushTestable.php
+++ b/tests/phpunit/Civi/ContactPushTestable.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Civi;
+
+/**
+ * Overrides CRM_Civixero_Contact::pushToXero() with a canned-response queue,
+ * so push() can be exercised end-to-end without any network access -
+ * regardless of whether pushToXero() itself talks to the legacy Xero
+ * package or the new xeroapi/xero-php-oauth2 SDK. See InvoiceMappingTestable
+ * for why this lives outside a *Test.php file.
+ */
+class ContactPushTestable extends \CRM_Civixero_Contact {
+
+  /**
+   * @var array
+   *   Queue of either ['result' => $value] or ['throw' => $exception].
+   */
+  public array $pushToXeroQueue = [];
+
+  /**
+   * @var array
+   *   The $accountsContact argument passed to pushToXero() on each call, in order.
+   */
+  public array $pushToXeroCalls = [];
+
+  protected function pushToXero($accountsContact, $connector_id) {
+    $this->pushToXeroCalls[] = $accountsContact;
+    // Preserve the real pushToXero()'s short-circuit: push() itself never
+    // checks $accountsContact for FALSE before calling pushToXero(), so
+    // this behaviour has to live here too, not just in the real method.
+    if ($accountsContact === FALSE) {
+      return FALSE;
+    }
+    if ($this->pushToXeroQueue === []) {
+      throw new \LogicException('ContactPushTestable::pushToXero() called with nothing queued');
+    }
+    $next = array_shift($this->pushToXeroQueue);
+    if (array_key_exists('throw', $next)) {
+      throw $next['throw'];
+    }
+    return $next['result'];
+  }
+
+}

--- a/tests/phpunit/Civi/ContactSdkPushTestable.php
+++ b/tests/phpunit/Civi/ContactSdkPushTestable.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Civi;
+
+use GuzzleHttp\ClientInterface;
+use XeroAPI\XeroPHP\Api\AccountingApi;
+use XeroAPI\XeroPHP\Configuration;
+
+/**
+ * Overrides CRM_Civixero_Contact::getAccountingApiInstance() so the real SDK
+ * (real request-building/serialization, real response deserialization) can
+ * be exercised against a mocked Guzzle HTTP client instead of the network.
+ * See InvoiceMappingTestable for why this lives outside a *Test.php file.
+ */
+class ContactSdkPushTestable extends \CRM_Civixero_Contact {
+
+  public ClientInterface $mockClient;
+
+  public function getAccountingApiInstance(): AccountingApi {
+    $config = Configuration::getDefaultConfiguration()->setAccessToken($this->getAccessToken());
+    return new AccountingApi($this->mockClient, $config);
+  }
+
+  public function callPushToXero($accountsContact, $connector_id) {
+    return $this->pushToXero($accountsContact, $connector_id);
+  }
+
+}

--- a/tests/phpunit/ContactMappingTest.php
+++ b/tests/phpunit/ContactMappingTest.php
@@ -1,0 +1,167 @@
+<?php
+
+use Civi\ContactMappingTestable;
+use Civi\MockConnector;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterization tests for CRM_Civixero_Contact::mapToAccounts() - the
+ * CiviCRM-array -> Xero-shaped-array mapping used by push(). Pins down
+ * current behaviour ahead of the Xero-SDK migration (which only touches
+ * pushToXero(), not this method).
+ *
+ * @group headless
+ */
+class ContactMappingTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  /**
+   * Set to veto (return FALSE) via hook_civicrm_accountPushAlterMapped().
+   *
+   * @var bool
+   */
+  public bool $vetoPush = FALSE;
+
+  /**
+   * Set to have hook_civicrm_accountPushAlterMapped() add a field to the
+   * mapped array before it's returned.
+   *
+   * @var bool
+   */
+  public bool $mutateViaHook = FALSE;
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->install('org.civicrm.search_kit')
+      ->install('nz.co.fuzion.accountsync')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp(): void {
+    Civi::$statics['civixero_connector'] = new MockConnector();
+    $this->vetoPush = FALSE;
+    $this->mutateViaHook = FALSE;
+    parent::setUp();
+  }
+
+  public function hook_civicrm_accountPushAlterMapped($entity, &$data, &$save, &$params) {
+    if ($this->vetoPush) {
+      $save = FALSE;
+    }
+    if ($this->mutateViaHook) {
+      $params['Custom'] = 'added by hook';
+    }
+  }
+
+  private function getBaseContact(array $overrides = []): array {
+    return $overrides + [
+      'id' => 123,
+      'display_name' => 'Jane Doe',
+      'first_name' => 'Jane',
+      'last_name' => 'Doe',
+    ];
+  }
+
+  public function testMapsNameFieldsAndContactNumber(): void {
+    $contact = new ContactMappingTestable([]);
+    $mapped = $contact->callMapToAccounts($this->getBaseContact(), NULL);
+
+    $this->assertIsArray($mapped);
+    $this->assertCount(1, $mapped);
+    $this->assertEquals('Jane Doe', $mapped[0]['Name']);
+    $this->assertEquals('Jane', $mapped[0]['FirstName']);
+    $this->assertEquals('Doe', $mapped[0]['LastName']);
+    $this->assertEquals(123, $mapped[0]['ContactNumber']);
+    $this->assertArrayNotHasKey('ContactID', $mapped[0]);
+    $this->assertEquals('', $mapped[0]['EmailAddress']);
+  }
+
+  public function testSetsContactIdOnlyWhenXeroUuidPassed(): void {
+    $contact = new ContactMappingTestable([]);
+
+    $withoutUuid = $contact->callMapToAccounts($this->getBaseContact(), NULL);
+    $this->assertArrayNotHasKey('ContactID', $withoutUuid[0]);
+
+    $withUuid = $contact->callMapToAccounts($this->getBaseContact(), 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    $this->assertEquals('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', $withUuid[0]['ContactID']);
+  }
+
+  public function testTruncatesLongDisplayNamePreservingIdSuffix(): void {
+    $contact = new ContactMappingTestable([]);
+    $longName = str_repeat('x', 300);
+
+    $mapped = $contact->callMapToAccounts($this->getBaseContact(['display_name' => $longName]), NULL);
+
+    $name = $mapped[0]['Name'];
+    $this->assertLessThanOrEqual(255, strlen($name));
+    // The ' - <id>' suffix must survive truncation - only the display-name
+    // portion is cut down.
+    $this->assertStringEndsWith(' - 123', $name);
+  }
+
+  public function testValidEmailIsPassedThrough(): void {
+    $contact = new ContactMappingTestable([]);
+    $mapped = $contact->callMapToAccounts($this->getBaseContact(['email' => 'jane@example.com']), NULL);
+    $this->assertEquals('jane@example.com', $mapped[0]['EmailAddress']);
+  }
+
+  public function testInvalidEmailIsDroppedNotVetoed(): void {
+    $contact = new ContactMappingTestable([]);
+    $mapped = $contact->callMapToAccounts($this->getBaseContact(['email' => 'not-an-email']), NULL);
+    // Invalid email doesn't stop the push - it's logged and pushed without one.
+    $this->assertNotFalse($mapped);
+    $this->assertEquals('', $mapped[0]['EmailAddress']);
+  }
+
+  public function testPhoneOnlyIncludedWhenSet(): void {
+    $contact = new ContactMappingTestable([]);
+
+    $withoutPhone = $contact->callMapToAccounts($this->getBaseContact(), NULL);
+    $this->assertArrayNotHasKey('Phones', $withoutPhone[0]);
+
+    $withPhone = $contact->callMapToAccounts($this->getBaseContact(['phone' => '0123456789']), NULL);
+    $this->assertEquals('0123456789', $withPhone[0]['Phones']['Phone']['PhoneNumber']);
+    $this->assertEquals('DEFAULT', $withPhone[0]['Phones']['Phone']['PhoneType']);
+  }
+
+  public function testAddressOnlyIncludedWhenAnAddressFieldIsSet(): void {
+    $contact = new ContactMappingTestable([]);
+
+    $withoutAddress = $contact->callMapToAccounts($this->getBaseContact(), NULL);
+    $this->assertArrayNotHasKey('Addresses', $withoutAddress[0]);
+
+    $withAddress = $contact->callMapToAccounts($this->getBaseContact([
+      'street_address' => '123 Main St',
+      'city' => 'Wellington',
+      'postal_code' => '6011',
+      'country' => 'New Zealand',
+      'state_province_name' => 'Wellington',
+    ]), NULL);
+    $address = $withAddress[0]['Addresses']['Address'][0];
+    $this->assertEquals('123 Main St', $address['AddressLine1']);
+    $this->assertEquals('Wellington', $address['City']);
+    $this->assertEquals('6011', $address['PostalCode']);
+    $this->assertEquals('New Zealand', $address['Country']);
+    $this->assertEquals('Wellington', $address['Region']);
+    $this->assertEquals('POBOX', $address['AddressType']);
+  }
+
+  public function testHookVetoReturnsFalse(): void {
+    $this->vetoPush = TRUE;
+    $contact = new ContactMappingTestable([]);
+    $mapped = $contact->callMapToAccounts($this->getBaseContact(), NULL);
+    $this->assertFalse($mapped);
+  }
+
+  public function testHookCanMutateMappedArrayBeforeReturn(): void {
+    $this->mutateViaHook = TRUE;
+    $contact = new ContactMappingTestable([]);
+    $mapped = $contact->callMapToAccounts($this->getBaseContact(), NULL);
+    $this->assertEquals('added by hook', $mapped[0]['Custom']);
+  }
+
+}

--- a/tests/phpunit/ContactPushTest.php
+++ b/tests/phpunit/ContactPushTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\ContactPushTestable;
 use Civi\MockConnector;
 use Civi\Test\Api3TestTrait;
 use Civi\Test\CiviEnvBuilder;
@@ -10,16 +11,14 @@ use Civi\Test\TransactionalInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
- * FIXME - Add test description.
+ * End-to-end characterization tests for CRM_Civixero_Contact::push().
  *
- * Tips:
- *  - With HookInterface, you may implement CiviCRM hooks directly in the test class.
- *    Simply create corresponding functions (e.g. "hook_civicrm_post(...)" or similar).
- *  - With TransactionalInterface, any data changes made by setUp() or test****() functions will
- *    rollback automatically -- as long as you don't manipulate schema or truncate tables.
- *    If this test needs to manipulate schema or truncate tables, then either:
- *       a. Do all that using setupHeadless() and Civi\Test.
- *       b. Disable TransactionalInterface, and handle all setup/teardown yourself.
+ * push() orchestrates: fetch queued AccountContacts -> map -> pushToXero() ->
+ * inline response-handling/dedupe. pushToXero() is the only piece the
+ * Xero-SDK migration touches, so these tests use ContactPushTestable to feed
+ * it canned responses/exceptions - proving push()'s surrounding
+ * orchestration (error handling, throttle abort, dedupe, DB updates) is
+ * independent of which client pushToXero() delegates to underneath.
  *
  * @group headless
  */
@@ -27,6 +26,14 @@ class ContactPushTest extends TestCase implements HeadlessInterface, HookInterfa
 
   use Api3TestTrait;
   use ContactTestTrait;
+
+  /**
+   * Set by testPushSkipsContactWhenMapToAccountsHookVetoes() to make
+   * hook_civicrm_accountPushAlterMapped() veto the push for this test only.
+   *
+   * @var bool
+   */
+  public bool $vetoPush = FALSE;
 
   /**
    * Setup used when HeadlessInterface is implemented.
@@ -49,7 +56,23 @@ class ContactPushTest extends TestCase implements HeadlessInterface, HookInterfa
 
   public function setUp():void {
     Civi::$statics['civixero_connector'] = new MockConnector();
+    CRM_Civixero_Base::resetApiRateLimitExceeded();
+    $this->vetoPush = FALSE;
     parent::setUp();
+  }
+
+  public function tearDown(): void {
+    CRM_Civixero_Base::resetApiRateLimitExceeded();
+    parent::tearDown();
+  }
+
+  /**
+   * hook_civicrm_accountPushAlterMapped - only vetoes when $this->vetoPush is set.
+   */
+  public function hook_civicrm_accountPushAlterMapped($entity, &$data, &$save, &$params) {
+    if ($this->vetoPush) {
+      $save = FALSE;
+    }
   }
 
   /**
@@ -67,10 +90,6 @@ class ContactPushTest extends TestCase implements HeadlessInterface, HookInterfa
    * push() builds its worklist from getContactsRequiringPushUpdate(); when
    * called with a contact_id it should return only that contact's queued
    * AccountContact record, not other contacts that are also queued.
-   *
-   * (push() itself isn't exercised here as it requires a real Xero
-   * connection to call getSingleton()->Contacts(); MockConnector only
-   * stands in for the OAuth token exchange.)
    */
   public function testGetContactsRequiringPushUpdateIsScopedToOneContact(): void {
     $targetContactID = $this->individualCreate([], 'target');
@@ -96,6 +115,269 @@ class ContactPushTest extends TestCase implements HeadlessInterface, HookInterfa
 
     $this->assertCount(1, $records);
     $this->assertEquals($targetContactID, $records[0]['contact_id']);
+  }
+
+  /**
+   * Create a Contact + queued AccountContact, ready for
+   * CRM_Civixero_Contact::push() to pick up.
+   *
+   * @return array{contact_id: int, account_contact_id: int}
+   */
+  private function createQueuedAccountContact(): array {
+    $contactID = $this->individualCreate();
+    // accountsync's own hook_civicrm_post may have already auto-created an
+    // AccountContact row for this contact (depending on this site's
+    // account_sync settings) - update that row rather than colliding with
+    // its unique index by inserting a second one.
+    $existing = \Civi\Api4\AccountContact::get(FALSE)
+      ->addWhere('contact_id', '=', $contactID)
+      ->addWhere('connector_id', '=', 0)
+      ->addWhere('plugin', '=', 'xero')
+      ->execute();
+    $params = [
+      'contact_id' => $contactID,
+      'plugin' => 'xero',
+      'connector_id' => 0,
+      'accounts_needs_update' => 1,
+    ];
+    if ($existing->count() > 0) {
+      $params['id'] = $existing->first()['id'];
+    }
+    $accountContact = $this->callAPISuccess('AccountContact', 'create', $params);
+    return [
+      'contact_id' => $contactID,
+      'account_contact_id' => $accountContact['id'],
+    ];
+  }
+
+  private function getCannedXeroContactResult(string $xeroContactID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'): array {
+    return [
+      'result' => [
+        'Contacts' => [
+          'Contact' => [
+            'ContactID' => $xeroContactID,
+            'UpdatedDateUTC' => '2024-03-15 10:00:00',
+            'Name' => 'Test Contact',
+          ],
+        ],
+      ],
+    ];
+  }
+
+  public function testPushSuccessUpdatesAccountContact(): void {
+    $fixture = $this->createQueuedAccountContact();
+    $contact = new ContactPushTestable([]);
+    $contact->pushToXeroQueue[] = $this->getCannedXeroContactResult();
+
+    $result = $contact->push(['connector_id' => 0], 10);
+
+    $this->assertTrue($result);
+    $this->assertCount(1, $contact->pushToXeroCalls);
+    // Read via API4 - API3's AccountContact.get runs accounts_data through
+    // CRM_Accountsync_Hook::mapAccountsData(), which unconditionally reads
+    // $accountsData['Addresses']/['Phones'] and warns on our minimal canned
+    // snapshot; that's an unrelated pre-existing quirk, not something this
+    // migration touches.
+    $saved = \Civi\Api4\AccountContact::get(FALSE)
+      ->addWhere('id', '=', $fixture['account_contact_id'])
+      ->execute()
+      ->single();
+    $this->assertEquals('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', $saved['accounts_contact_id']);
+    $this->assertEquals('Test Contact', $saved['accounts_display_name']);
+    $this->assertEquals(0, $saved['accounts_needs_update']);
+  }
+
+  public function testPushWithNoQueuedContactsReturnsTrueWithoutCallingPushToXero(): void {
+    $contact = new ContactPushTestable([]);
+    $result = $contact->push(['connector_id' => 0], 10);
+    $this->assertTrue($result);
+    $this->assertCount(0, $contact->pushToXeroCalls);
+  }
+
+  public function testPushSetsDoNotSyncWhenContactIsDeleted(): void {
+    $fixture = $this->createQueuedAccountContact();
+    \Civi\Api4\Contact::update(FALSE)
+      ->addWhere('id', '=', $fixture['contact_id'])
+      ->addValue('is_deleted', TRUE)
+      ->execute();
+    $contact = new ContactPushTestable([]);
+
+    $result = $contact->push(['connector_id' => 0], 10);
+
+    $this->assertTrue($result);
+    $this->assertCount(0, $contact->pushToXeroCalls);
+    $saved = \Civi\Api4\AccountContact::get(FALSE)
+      ->addWhere('id', '=', $fixture['account_contact_id'])
+      ->execute()
+      ->single();
+    $this->assertEquals(1, $saved['do_not_sync']);
+  }
+
+  public function testPushThrowsWhenXeroContactAlreadyLinkedToDifferentLiveContact(): void {
+    $fixtureA = $this->createQueuedAccountContact();
+    $otherContactID = $this->individualCreate();
+    $xeroContactID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    // Existing AccountContact row already linking that Xero ContactID to a
+    // DIFFERENT (live) CiviCRM contact.
+    $this->callAPISuccess('AccountContact', 'create', [
+      'contact_id' => $otherContactID,
+      'plugin' => 'xero',
+      'connector_id' => 0,
+      'accounts_contact_id' => $xeroContactID,
+      // Already synced - not itself queued for push, so this test only
+      // exercises the dedupe/conflict check on fixtureA's push.
+      'accounts_needs_update' => 0,
+    ]);
+    $contact = new ContactPushTestable([]);
+    $contact->pushToXeroQueue[] = $this->getCannedXeroContactResult($xeroContactID);
+
+    try {
+      $contact->push(['connector_id' => 0], 10);
+      $this->fail('Expected push() to throw because the Xero contact is already linked elsewhere');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertStringContainsString('Not all contacts were saved', $e->getMessage());
+    }
+
+    $saved = \Civi\Api4\AccountContact::get(FALSE)
+      ->addWhere('id', '=', $fixtureA['account_contact_id'])
+      ->execute()
+      ->single();
+    $this->assertNotEmpty($saved['error_data']);
+    $this->assertStringContainsString('Attempt to sync Contact', $saved['error_data']);
+  }
+
+  public function testPushRepairsStaleAccountContactRowWhenMatchedContactIsDeleted(): void {
+    $fixtureA = $this->createQueuedAccountContact();
+    $deletedContactID = $this->individualCreate();
+    \Civi\Api4\Contact::update(FALSE)
+      ->addWhere('id', '=', $deletedContactID)
+      ->addValue('is_deleted', TRUE)
+      ->execute();
+    $xeroContactID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    $staleRow = $this->callAPISuccess('AccountContact', 'create', [
+      'contact_id' => $deletedContactID,
+      'plugin' => 'xero',
+      'connector_id' => 0,
+      'accounts_contact_id' => $xeroContactID,
+      // Already synced - not itself queued for push. (accounts_needs_update
+      // defaults to TRUE; leaving it set would queue this row too, and
+      // since its own contact is deleted, its is_deleted branch would mark
+      // do_not_sync=TRUE and clobber the repair this test is checking for.)
+      'accounts_needs_update' => 0,
+    ]);
+    $contact = new ContactPushTestable([]);
+    $contact->pushToXeroQueue[] = $this->getCannedXeroContactResult($xeroContactID);
+
+    $result = $contact->push(['connector_id' => 0], 10);
+
+    $this->assertTrue($result);
+    // fixtureA's original row was deleted; the stale row was repaired
+    // in-place and now carries fixtureA's contact.
+    $remaining = \Civi\Api4\AccountContact::get(FALSE)
+      ->addWhere('id', 'IN', [$fixtureA['account_contact_id'], $staleRow['id']])
+      ->execute();
+    $this->assertCount(1, $remaining);
+    $repaired = $remaining->first();
+    $this->assertEquals($staleRow['id'], $repaired['id']);
+    $this->assertEquals($fixtureA['contact_id'], $repaired['contact_id']);
+    $this->assertEquals(0, $repaired['do_not_sync']);
+    $this->assertEquals($xeroContactID, $repaired['accounts_contact_id']);
+  }
+
+  public function testPushRecordsErrorAndContinuesWhenPushToXeroThrowsCoreException(): void {
+    $fixtureA = $this->createQueuedAccountContact();
+    $fixtureB = $this->createQueuedAccountContact();
+    $contact = new ContactPushTestable([]);
+    // getContactsRequiringPushUpdate() orders by error_data (nulls first),
+    // so insertion order among two fresh (error_data IS NULL) rows isn't
+    // guaranteed - queue the same failure/success pair regardless of which
+    // fixture is processed first, and assert on totals instead of identity.
+    $contact->pushToXeroQueue[] = ['throw' => new CRM_Core_Exception('Xero rejected the contact')];
+    $contact->pushToXeroQueue[] = $this->getCannedXeroContactResult();
+
+    try {
+      $contact->push(['connector_id' => 0], 10);
+      $this->fail('Expected push() to throw because one record failed');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertStringContainsString('Not all contacts were saved', $e->getMessage());
+    }
+
+    // Both records were attempted (the failure didn't abort the loop).
+    $this->assertCount(2, $contact->pushToXeroCalls);
+    $accountContacts = (array) \Civi\Api4\AccountContact::get(FALSE)
+      ->addWhere('id', 'IN', [$fixtureA['account_contact_id'], $fixtureB['account_contact_id']])
+      ->execute();
+    $withError = array_filter($accountContacts, fn($r) => !empty($r['error_data'] ?? NULL));
+    $withoutError = array_filter($accountContacts, fn($r) => empty($r['error_data'] ?? NULL));
+    $this->assertCount(1, $withError);
+    $this->assertCount(1, $withoutError);
+    $failed = reset($withError);
+    $this->assertStringContainsString('Xero rejected the contact', $failed['error_data']);
+    // Still queued for retry - a generic CRM_Core_Exception isn't a
+    // permanent failure (accounts_needs_update is never cleared on this path).
+    $this->assertEquals(1, $failed['accounts_needs_update']);
+  }
+
+  public function testPushAbortsRemainingRecordsAndSetsRateLimitOnThrottle(): void {
+    $this->createQueuedAccountContact();
+    $this->createQueuedAccountContact();
+    $contact = new ContactPushTestable([]);
+    $contact->pushToXeroQueue[] = ['throw' => new CRM_Civixero_Exception_XeroThrottle('Rate limited', 429, NULL, time() + 3600)];
+
+    try {
+      $contact->push(['connector_id' => 0], 10);
+      $this->fail('Expected push() to throw because Xero throttled the request');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertStringContainsString('Contact Push aborted due to throttling by Xero', $e->getMessage());
+    }
+
+    // The throttle exception aborts the whole loop - the second record is
+    // never attempted.
+    $this->assertCount(1, $contact->pushToXeroCalls);
+    $this->assertNotEmpty(Civi::settings()->get('xero_oauth_rate_exceeded'));
+  }
+
+  /**
+   * mapToAccounts() returning FALSE (hook veto via accountPushAlterMapped)
+   * pins down a genuine PRE-EXISTING bug, confirmed here rather than fixed:
+   * pushToXero() correctly short-circuits to FALSE without consulting the
+   * queue, but push() itself never checks for that FALSE before using it as
+   * an array (unlike Invoice::push(), which checks $mappedAccountInvoice for
+   * FALSE/NULL before calling pushToXero() at all). The dedupe-lookup on
+   * $result['Contacts']['Contact']['ContactID'] then reads array offsets off
+   * a boolean, which PHPUnit's error handler escalates into a thrown
+   * ErrorException - so the record ends up recorded as a push FAILURE
+   * (error_data set, is_error_resolved cleared) instead of being skipped
+   * cleanly. Out of scope to fix here (the SDK migration only touches
+   * pushToXero()), but worth flagging as a small, separate bugfix.
+   */
+  public function testPushSkipsContactWhenMapToAccountsHookVetoes(): void {
+    $fixture = $this->createQueuedAccountContact();
+    $this->vetoPush = TRUE;
+    $contact = new ContactPushTestable([]);
+    // pushToXero() itself still gets called with $accountsContact === FALSE
+    // and correctly short-circuits to FALSE without consulting the queue -
+    // nothing needs to be queued for it.
+
+    try {
+      $contact->push(['connector_id' => 0], 10);
+      $this->fail('Expected push() to throw - see docblock above for why this is a pre-existing bug, not the intended behaviour');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertStringContainsString('Not all contacts were saved', $e->getMessage());
+    }
+
+    $this->assertCount(1, $contact->pushToXeroCalls);
+    $this->assertFalse($contact->pushToXeroCalls[0]);
+    $saved = \Civi\Api4\AccountContact::get(FALSE)
+      ->addWhere('id', '=', $fixture['account_contact_id'])
+      ->execute()
+      ->single();
+    $this->assertNotEmpty($saved['error_data']);
+    $this->assertStringContainsString('Trying to access array offset on false', $saved['error_data']);
   }
 
 }

--- a/tests/phpunit/ContactSdkPushTest.php
+++ b/tests/phpunit/ContactSdkPushTest.php
@@ -1,0 +1,174 @@
+<?php
+
+use Civi\ContactSdkPushTestable;
+use Civi\MockConnector;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\GuzzleTestTrait;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises pushViaApi() against the real xeroapi/xero-php-oauth2
+ * AccountingApi with a mocked Guzzle HTTP client (Civi\Test\GuzzleTestTrait,
+ * the same pattern core uses for testing payment-gateway integrations, and
+ * the same pattern used for InvoiceSdkPushTest) - so the SDK's own request
+ * building/serialization and response deserialization run for real, only
+ * the network call itself is faked.
+ *
+ * @group headless
+ */
+class ContactSdkPushTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  use GuzzleTestTrait;
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->install('org.civicrm.search_kit')
+      ->install('nz.co.fuzion.accountsync')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp(): void {
+    Civi::$statics['civixero_connector'] = new MockConnector();
+    parent::setUp();
+  }
+
+  private function getMappedContact(array $overrides = []): array {
+    return $overrides + [
+      'Name' => 'Jane Doe - 123',
+      'FirstName' => 'Jane',
+      'LastName' => 'Doe',
+      'EmailAddress' => 'jane@example.com',
+      'ContactNumber' => 123,
+    ];
+  }
+
+  private function getContactWithMockClient(): ContactSdkPushTestable {
+    $this->setUpClientWithHistoryContainer();
+    $contact = new ContactSdkPushTestable([]);
+    $contact->mockClient = $this->getGuzzleClient();
+    return $contact;
+  }
+
+  public function testPushToXeroSuccessReturnsLegacyShapedContactResult(): void {
+    $this->createMockHandler([
+      json_encode([
+        'Contacts' => [
+          [
+            'ContactID' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+            'Name' => 'Jane Doe - 123',
+            'ContactNumber' => '123',
+            'UpdatedDateUTC' => '2024-03-15T10:00:00',
+          ],
+        ],
+      ]),
+    ]);
+    $contact = $this->getContactWithMockClient();
+
+    $result = $contact->callPushToXero($this->getMappedContact(), 0);
+
+    $this->assertEquals(
+      'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      $result['Contacts']['Contact']['ContactID']
+    );
+    $this->assertEquals('Jane Doe - 123', $result['Contacts']['Contact']['Name']);
+    $this->assertEquals('2024-03-15 10:00:00', $result['Contacts']['Contact']['UpdatedDateUTC']);
+  }
+
+  public function testPushToXeroSendsIdempotencyKeyUnderXeroLimit(): void {
+    $this->createMockHandler([
+      json_encode([
+        'Contacts' => [
+          ['ContactID' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', 'Name' => 'Jane Doe - 123', 'UpdatedDateUTC' => '2024-03-15T10:00:00'],
+        ],
+      ]),
+    ]);
+    $contact = $this->getContactWithMockClient();
+
+    $contact->callPushToXero($this->getMappedContact(), 0);
+
+    $headers = $this->getRequestHeaders();
+    $this->assertCount(1, $headers);
+    $this->assertArrayHasKey('Idempotency-Key', $headers[0]);
+    $key = $headers[0]['Idempotency-Key'][0];
+    $this->assertLessThanOrEqual(128, strlen($key));
+    $this->assertStringStartsWith('civixero-contact-123-', $key);
+  }
+
+  public function testPushToXeroRejectsMalformedStoredContactIdBeforeCallingXero(): void {
+    $contact = $this->getContactWithMockClient();
+    // No response queued on the mock handler - if this reaches the HTTP
+    // layer at all, the test will fail with a MockHandler "no more
+    // responses" error rather than the expected CRM_Core_Exception,
+    // proving the GUID check happens client-side before any request goes out.
+    $mapped = $this->getMappedContact(['ContactID' => 'not-a-guid']);
+
+    $this->expectException(CRM_Core_Exception::class);
+    $this->expectExceptionMessageMatches('/not a valid Xero ID/');
+    $contact->callPushToXero($mapped, 0);
+  }
+
+  /**
+   * This is the seam the SDK migration actually changes: pushViaApi()
+   * (unlike the legacy pushToXero()) returns a top-level 'ValidationErrors'
+   * key on a Xero validation failure - Base::validateResponse() already
+   * recognises that shape (added for Invoice/BankTransaction's migration),
+   * so push()'s error handling needs no changes.
+   */
+  public function testPushToXeroValidationFailureReturnsTopLevelValidationErrorsShape(): void {
+    $this->createMockHandler([
+      json_encode([
+        'Contacts' => [
+          [
+            'Name' => 'Jane Doe - 123',
+            'ValidationErrors' => [
+              ['Message' => 'Email address must be valid'],
+            ],
+          ],
+        ],
+      ]),
+    ]);
+    $contact = $this->getContactWithMockClient();
+
+    $result = $contact->callPushToXero($this->getMappedContact(), 0);
+
+    $this->assertEquals(['ValidationErrors' => ['Email address must be valid']], $result);
+  }
+
+  /**
+   * pushToXero()'s catch blocks catch \XeroAPI\XeroPHP\ApiException (the SDK's
+   * HTTP-error exception, e.g. for a 429 rate-limit response) and translate
+   * a 429 into CRM_Civixero_Exception_XeroThrottle, mirroring
+   * Invoice::pushToXero() - so push()'s throttle-abort-and-backoff handling
+   * (see ContactPushTest::testPushAbortsRemainingRecordsAndSetsRateLimitOnThrottle)
+   * keeps working once pushToXero() delegates to the SDK.
+   */
+  public function testPushToXeroTranslatesSdk429ResponseToThrottleException(): void {
+    $this->createMockHandler([]);
+    // createMockHandler() only builds 200s - queue a 429 directly.
+    $this->getMockHandler()->append(new \GuzzleHttp\Psr7\Response(429, ['Retry-After' => '120'], json_encode(['Message' => 'Rate limit exceeded'])));
+    $contact = $this->getContactWithMockClient();
+
+    try {
+      $contact->callPushToXero($this->getMappedContact(), 0);
+      $this->fail('Expected a CRM_Civixero_Exception_XeroThrottle to be thrown');
+    }
+    catch (CRM_Civixero_Exception_XeroThrottle $e) {
+      $this->assertGreaterThan(time(), $e->getRetryAfter());
+    }
+  }
+
+  public function testPushToXeroTranslatesOtherSdkApiExceptionsToCoreException(): void {
+    $this->createMockHandler([]);
+    $this->getMockHandler()->append(new \GuzzleHttp\Psr7\Response(500, [], json_encode(['Message' => 'Internal error'])));
+    $contact = $this->getContactWithMockClient();
+
+    $this->expectException(CRM_Core_Exception::class);
+    $this->expectExceptionMessageMatches('/Synchronization error/');
+    $contact->callPushToXero($this->getMappedContact(), 0);
+  }
+
+}


### PR DESCRIPTION
Same treatment as #215/#218 (Invoice/BankTransaction), applied to Contact push. `pullFromXero()` was already on the SDK; `push()` still called the legacy client.

- Characterization tests first (pin down current `push()` orchestration and `mapToAccounts()` mapping) before touching any implementation
- `pushViaApi()` mirrors Invoice/BankTransaction's shape-preserving adapter: calls `updateOrCreateContacts()`, returns the same legacy-shaped array `push()` already reads (`['Contacts']['Contact'][...]` / `['ValidationErrors' => [...]]`) - no downstream changes needed
- `pushToXero()` translates SDK exceptions the same way `Invoice::pushToXero()` does (429 -> `CRM_Civixero_Exception_XeroThrottle`)
- SDK-level tests against a mocked Guzzle client cover create/update, validation errors, malformed `ContactID`, and throttle/error translation
- Full civixero suite: 60/60 passing, no regressions

Characterization also surfaced a pre-existing bug (unrelated to this migration, left as-is and pinned down by a test): a hook veto returning `FALSE` from `mapToAccounts()` makes `push()` read array offsets off that boolean instead of skipping cleanly, so the record is recorded as a failure rather than skipped. Worth a small separate fix.

Deliberately does **not** carry forward #216's duplicate-contact/phone-matching feature - that's new behaviour (not a port), with its own AU-specific assumptions, so it needs its own design/review rather than riding along with a "no behaviour change" migration.