### PR TITLE
Account Sync Settings Check

### DIFF
--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -205,6 +205,20 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
         ->addWhere('accounts_invoice_id', '=', $xeroInvoice['invoice_id'])
         ->execute()
         ->first();
+
+      $matchedByInvoiceNumber = FALSE;
+      if (empty($accountInvoice) || empty($accountInvoice['contribution_id'])) {
+        $matchResult = $this->getContributionIDFromInvoiceNumberMatch($xeroInvoice, $connectorID);
+        if ($matchResult) {
+          // A reliable match takes precedence over the prefix-derived one.
+          $matchedByInvoiceNumber = TRUE;
+          $accountInvoiceParams['contribution_id'] = $matchResult;
+        }
+        elseif ($matchResult === FALSE) {
+          unset($accountInvoiceParams['contribution_id']);
+        }
+        // NULL: no candidate (or setting disabled) - keep any prefix-derived ID.
+      }
       try {
         if (empty($accountInvoice)) {
           // Invoice is in Xero but (accounts_invoice_id) does not exist in account_invoice table
@@ -212,12 +226,37 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
           //   derived from Xero invoice ID without prefix.
           // So we can't use contribution ID - remove it, and then we'll record a new entry in account_invoice with Xero invoice.
           // This could be manually reconciled by adding a contribution ID.
-          // Create a new AccountInvoice record
-          unset($accountInvoiceParams['contribution_id']);
-          $newAccountInvoice = AccountInvoice::create(FALSE)
-            ->setValues($accountInvoiceParams)
-            ->execute()
-            ->first();
+          // The exception is an exact match on the contribution's invoice_number
+          // (guarded by uniqueness/amount checks) which is reliable enough to link.
+          if (!$matchedByInvoiceNumber) {
+            unset($accountInvoiceParams['contribution_id']);
+          }
+          $pendingAccountInvoice = NULL;
+          if ($matchedByInvoiceNumber) {
+            $pendingAccountInvoice = AccountInvoice::get(FALSE)
+              ->addWhere('plugin', '=', $this->_plugin)
+              ->addWhere('connector_id', '=', $connectorID)
+              ->addWhere('contribution_id', '=', $accountInvoiceParams['contribution_id'])
+              ->addWhere('accounts_invoice_id', 'IS NULL')
+              ->execute()
+              ->first();
+          }
+          if (!empty($pendingAccountInvoice)) {
+            $adoptParams = $accountInvoiceParams;
+            unset($adoptParams['accounts_needs_update']);
+            $newAccountInvoice = AccountInvoice::update(FALSE)
+              ->setValues($adoptParams)
+              ->addWhere('id', '=', $pendingAccountInvoice['id'])
+              ->execute()
+              ->first();
+          }
+          else {
+            // Create a new AccountInvoice record
+            $newAccountInvoice = AccountInvoice::create(FALSE)
+              ->setValues($accountInvoiceParams)
+              ->execute()
+              ->first();
+          }
           $ids[] = $newAccountInvoice['id'];
         }
         else {
@@ -227,29 +266,39 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
             'accounts_status_id',
             'accounts_needs_update',
           ];
+          // Every time we do an "update" last_sync_date is updated which triggers an entry in log_civicrm_account_contact.
+          // So check if anything actually changed before updating.
+          $somethingChanged = FALSE;
           foreach ($modifiedFieldKeys as $key) {
-            // Every time we do an "update" last_sync_date is updated which triggers an entry in log_civicrm_account_contact.
-            // So check if anything actually changed before updating.
             if ($accountInvoiceParams[$key] !== $accountInvoice[$key]) {
-              // Something changed, update AccountInvoice in DB
-              if (!empty($accountInvoice['contribution_id'])) {
-                // If the accountInvoice already has a contribution ID don't try to overwrite it with the one we derived from InvoiceNumber.
-                // Probably we manually reconciled it at some point.
-                unset($accountInvoiceParams['contribution_id']);
-              }
-              if (isset($accountInvoiceParams['contribution_id']) && empty(Contribution::get(FALSE)->addWhere('id', '=', $accountInvoiceParams['contribution_id'])->execute()->first())) {
-                // This happens if we deleted the contribution in CiviCRM
-                $accountInvoiceParams['error_data'] = json_encode(['error' => "ContributionID {$accountInvoiceParams['contribution_id']} not found in CiviCRM. If you deleted it you can mark this as resolved."]);
-                unset($accountInvoiceParams['contribution_id']);
-              }
-              $newAccountInvoice = AccountInvoice::update(FALSE)
-                ->setValues($accountInvoiceParams)
-                ->addWhere('id', '=', $accountInvoice['id'])
-                ->execute()
-                ->first();
-              $ids[] = $newAccountInvoice['id'];
+              $somethingChanged = TRUE;
               break;
             }
+          }
+          // A reliable invoice-number match that back-fills a missing
+          // contribution link is a change in its own right - otherwise
+          // existing unlinked rows are never reconnected unless a tracked
+          // field happens to have changed in Xero since the last pull.
+          if (!$somethingChanged && $matchedByInvoiceNumber && empty($accountInvoice['contribution_id']) && isset($accountInvoiceParams['contribution_id'])) {
+            $somethingChanged = TRUE;
+          }
+          if ($somethingChanged) {
+            if (!empty($accountInvoice['contribution_id'])) {
+              // If the accountInvoice already has a contribution ID don't try to overwrite it with the one we derived from InvoiceNumber.
+              // Probably we manually reconciled it at some point.
+              unset($accountInvoiceParams['contribution_id']);
+            }
+            if (isset($accountInvoiceParams['contribution_id']) && empty(Contribution::get(FALSE)->addWhere('id', '=', $accountInvoiceParams['contribution_id'])->execute()->first())) {
+              // This happens if we deleted the contribution in CiviCRM
+              $accountInvoiceParams['error_data'] = json_encode(['error' => "ContributionID {$accountInvoiceParams['contribution_id']} not found in CiviCRM. If you deleted it you can mark this as resolved."]);
+              unset($accountInvoiceParams['contribution_id']);
+            }
+            $newAccountInvoice = AccountInvoice::update(FALSE)
+              ->setValues($accountInvoiceParams)
+              ->addWhere('id', '=', $accountInvoice['id'])
+              ->execute()
+              ->first();
+            $ids[] = $newAccountInvoice['id'];
           }
         }
         if ($createContributionInCiviCRM) {
@@ -408,10 +457,6 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
     // Get default Invoice status
     $status = $this->settings->get('xero_default_invoice_status');
 
-    $prefix = $this->settings->get('xero_invoice_number_prefix');
-    if (empty($prefix)) {
-      $prefix = '';
-    }
     $new_invoice = [
       'Type' => ($total_amount > 0) ? 'ACCREC' : 'ACCPAY',
       'Contact' => [
@@ -420,7 +465,7 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
       'Date' => substr($invoiceData['receive_date'], 0, 10),
       'DueDate' => substr($invoiceData['receive_date'], 0, 10),
       'Status' => $status,
-      'InvoiceNumber' => $prefix . $invoiceData['id'],
+      'InvoiceNumber' => $this->getInvoiceNumber((int) ($invoiceData['id'] ?? NULL), $invoiceData['invoice_number'] ?? NULL),
       'CurrencyCode' => $invoiceData['currency'],
       'Reference' => $invoiceData['display_name'] . ' ' . $invoiceData['contribution_source'],
       'LineAmountTypes' => $line_amount_types,
@@ -457,11 +502,10 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
    * @return array
    */
   protected function mapCancelled(int $contributionID, ?string $xeroInvoiceUUID): array {
-    $prefix = $this->settings->get('xero_invoice_number_prefix') ?: '';
     return [
       'Invoice' => [
         'InvoiceID' => $xeroInvoiceUUID,
-        'InvoiceNumber' => $prefix . $contributionID,
+        'InvoiceNumber' => $this->getInvoiceNumber($contributionID),
         'Type' => 'ACCREC',
         'Reference' => 'Cancelled',
         'Date' => date('Y-m-d'),
@@ -478,6 +522,119 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
         ],
       ],
     ];
+  }
+
+  /**
+   * Get the invoice number to send to Xero for a contribution.
+   *
+   * @param int $contributionID
+   * @param string|null $contributionInvoiceNumber
+   *   The contribution's invoice_number if already known by the caller.
+   *   Pass NULL to have it looked up when required.
+   *
+   * @return string
+   */
+  protected function getInvoiceNumber(int $contributionID, ?string $contributionInvoiceNumber = NULL): string {
+    if ($this->settings->get('xero_use_contribution_invoice_number')) {
+      if ($contributionInvoiceNumber === NULL) {
+        try {
+          $contributionInvoiceNumber = (string) (Contribution::get(FALSE)
+            ->addSelect('invoice_number')
+            ->addWhere('id', '=', $contributionID)
+            ->execute()
+            ->first()['invoice_number'] ?? '');
+        }
+        catch (Exception $e) {
+          \Civi::log('civixero')->warning('getInvoiceNumber: could not load invoice_number for contribution ' . $contributionID . ': ' . $e->getMessage());
+          $contributionInvoiceNumber = '';
+        }
+      }
+      // Explicit check rather than empty(): the string '0' is a valid
+      // (if unlikely) invoice number and empty('0') is TRUE.
+      if ($contributionInvoiceNumber !== NULL && $contributionInvoiceNumber !== '') {
+        return (string) $contributionInvoiceNumber;
+      }
+    }
+    $prefix = $this->settings->get('xero_invoice_number_prefix') ?: '';
+
+    return $prefix . $contributionID;
+  }
+
+  /**
+   * Try to match a pulled Xero invoice to a contribution by invoice number.
+   *
+   * @param array $xeroInvoice
+   *   Invoice data pulled from Xero (needs invoice_number, invoice_id, total).
+   * @param int $connectorID
+   *   ID of the connector (0 if nz.co.fuzion.connectors is not installed).
+   *
+   * @return int|false|null
+   *   - int: the matched contribution ID.
+   *   - NULL: no candidate (or setting disabled) - the caller may fall back
+   *     to other matching strategies.
+   *   - FALSE: a candidate was found but refused as unsafe (duplicate
+   *     invoice_number, linked to a different Xero invoice, or total
+   *     mismatch) - the caller must NOT fall back to weaker matching.
+   */
+  protected function getContributionIDFromInvoiceNumberMatch(array $xeroInvoice, int $connectorID) {
+    $xeroInvoiceNumber = $xeroInvoice['invoice_number'] ?? NULL;
+    // Explicit check rather than empty(): the string '0' is a valid
+    // (if unlikely) invoice number and empty('0') is TRUE.
+    if (!$this->getSetting('xero_use_contribution_invoice_number') || $xeroInvoiceNumber === NULL || $xeroInvoiceNumber === '') {
+      return NULL;
+    }
+
+    $contributions = Contribution::get(FALSE)
+      ->addSelect('id', 'total_amount')
+      ->addWhere('invoice_number', '=', $xeroInvoice['invoice_number'])
+      ->addWhere('is_test', '=', FALSE)
+      ->addWhere('is_template', '=', FALSE)
+      ->setLimit(2)
+      ->execute();
+    if (count($contributions) === 0) {
+      // No candidate - the caller may fall back to other matching strategies.
+      return NULL;
+    }
+    if (count($contributions) > 1) {
+      \Civi::log('civixero')->warning('Invoice pull: multiple contributions share invoice_number {invoiceNumber} - not linking Xero invoice {xeroInvoiceID}.', [
+        'invoiceNumber' => $xeroInvoice['invoice_number'],
+        'xeroInvoiceID' => $xeroInvoice['invoice_id'] ?? '',
+      ]);
+      return FALSE;
+    }
+    $contribution = $contributions->first();
+
+    // Don't steal a contribution that is already linked to a different Xero invoice.
+    $existingLink = AccountInvoice::get(FALSE)
+      ->addSelect('id', 'accounts_invoice_id')
+      ->addWhere('plugin', '=', $this->_plugin)
+      ->addWhere('connector_id', '=', $connectorID)
+      ->addWhere('contribution_id', '=', $contribution['id'])
+      ->execute()
+      ->first();
+    if (!empty($existingLink['accounts_invoice_id']) && $existingLink['accounts_invoice_id'] !== ($xeroInvoice['invoice_id'] ?? '')) {
+      \Civi::log('civixero')->warning('Invoice pull: contribution {contributionID} (invoice_number {invoiceNumber}) is already linked to Xero invoice {existing} - not linking Xero invoice {xeroInvoiceID}.', [
+        'contributionID' => $contribution['id'],
+        'invoiceNumber' => $xeroInvoice['invoice_number'],
+        'existing' => $existingLink['accounts_invoice_id'],
+        'xeroInvoiceID' => $xeroInvoice['invoice_id'] ?? '',
+      ]);
+      return FALSE;
+    }
+
+    // Sanity check: totals should match.
+    if (isset($xeroInvoice['total']) && isset($contribution['total_amount'])
+      && abs(abs((float) $xeroInvoice['total']) - abs((float) $contribution['total_amount'])) > 0.011) {
+      \Civi::log('civixero')->warning('Invoice pull: Xero invoice {xeroInvoiceID} total {xeroTotal} does not match contribution {contributionID} total {civiTotal} - not linking despite invoice_number match.', [
+        'xeroInvoiceID' => $xeroInvoice['invoice_id'] ?? '',
+        'xeroTotal' => $xeroInvoice['total'],
+        'contributionID' => $contribution['id'],
+        'civiTotal' => $contribution['total_amount'],
+      ]);
+      return FALSE;
+    }
+
+    return (int) $contribution['id'];
   }
 
   /**

--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -346,6 +346,16 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
     try {
       foreach ($accountInvoices as $accountInvoice) {
         try {
+          if (!$this->isContributionEligibleForPush($accountInvoice)) {
+            // The accountsync queue-time settings no longer allow this
+            // contribution accountsync will re-queue it if a later edit makes
+            // it eligible again.
+            AccountInvoice::update(FALSE)
+              ->addWhere('id', '=', $accountInvoice['id'])
+              ->addValue('accounts_needs_update', FALSE)
+              ->execute();
+            continue;
+          }
           $mappedAccountInvoice = $this->getMappedAccountInvoice($accountInvoice);
           if ($mappedAccountInvoice === NULL) {
             // Contact not yet synced to Xero — leave accounts_needs_update set and try again next run.
@@ -405,6 +415,93 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
     }
     return $count;
 
+  }
+
+  /**
+   * Re-check the accountsync queue-time settings at push time.
+   *
+   * @param array $accountInvoice
+   *   The AccountInvoice record queued for push.
+   *
+   * @return bool
+   *   TRUE if the push should proceed.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function isContributionEligibleForPush(array $accountInvoice): bool {
+    $contributionID = $accountInvoice['contribution_id'] ?? NULL;
+    if (!$contributionID) {
+      // Nothing to check against - let the existing flow handle it.
+      return TRUE;
+    }
+    $contribution = Contribution::get(FALSE)
+      ->addSelect('contribution_status_id', 'receive_date')
+      ->addWhere('id', '=', $contributionID)
+      ->execute()
+      ->first();
+    if (empty($contribution)) {
+      // Deleted contribution - the existing flow records this as an error.
+      return TRUE;
+    }
+
+    // 1. Push Contribution Status.
+    $enabledStatuses = (array) \Civi::settings()->get('account_sync_push_contribution_status');
+    if (!empty($enabledStatuses) && !in_array($contribution['contribution_status_id'], $enabledStatuses)) {
+      \Civi::log('civixero')->info('Invoice push: skipping contribution {contributionID} - status {statusID} is not an enabled push status.', [
+        'contributionID' => $contributionID,
+        'statusID' => $contribution['contribution_status_id'],
+      ]);
+      return FALSE;
+    }
+
+    // 2. Day zero for contributions.
+    $dayZero = \Civi::settings()->get('account_sync_contribution_day_zero');
+    if (!empty($dayZero) && !empty($contribution['receive_date'])) {
+      try {
+        if (new DateTime($contribution['receive_date']) < new DateTime($dayZero)) {
+          \Civi::log('civixero')->info('Invoice push: skipping contribution {contributionID} - received {receiveDate}, before day zero {dayZero}.', [
+            'contributionID' => $contributionID,
+            'receiveDate' => $contribution['receive_date'],
+            'dayZero' => $dayZero,
+          ]);
+          return FALSE;
+        }
+      }
+      catch (Exception $e) {
+        // Don't block the push on an unparseable date - but do surface it,
+        // since a silently ignored day zero is exactly the bug this check
+        // exists to prevent.
+        \Civi::log('civixero')->warning('Invoice push: could not compare receive_date {receiveDate} with day zero {dayZero}: {message}', [
+          'receiveDate' => $contribution['receive_date'],
+          'dayZero' => $dayZero,
+          'message' => $e->getMessage(),
+        ]);
+      }
+    }
+
+    // 3. Skip invoice creation by payment processor.
+    $skipProcessorIDs = array_filter((array) \Civi::settings()->get('account_sync_skip_inv_by_pymt_processor'));
+    if (!empty($skipProcessorIDs)) {
+      $processorTrxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+        ->addSelect('financial_trxn_id.payment_processor_id')
+        ->addWhere('entity_table', '=', 'civicrm_contribution')
+        ->addWhere('entity_id', '=', $contributionID)
+        ->addWhere('financial_trxn_id.payment_processor_id', 'IS NOT NULL')
+        ->addOrderBy('financial_trxn_id', 'DESC')
+        ->setLimit(1)
+        ->execute()
+        ->first();
+      $paymentProcessorID = $processorTrxn['financial_trxn_id.payment_processor_id'] ?? NULL;
+      if ($paymentProcessorID && in_array($paymentProcessorID, $skipProcessorIDs)) {
+        \Civi::log('civixero')->info('Invoice push: skipping contribution {contributionID} - paid via payment processor {processorID} which is configured to be skipped.', [
+          'contributionID' => $contributionID,
+          'processorID' => $paymentProcessorID,
+        ]);
+        return FALSE;
+      }
+    }
+
+    return TRUE;
   }
 
   /**

--- a/settings/Civixero.setting.php
+++ b/settings/Civixero.setting.php
@@ -112,6 +112,18 @@ return [
     ],
     'settings_pages' => ['xero' => ['weight' => 2]],
   ],
+  'xero_use_contribution_invoice_number' => [
+    'name' => 'xero_use_contribution_invoice_number',
+    'type' => 'Boolean',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'default' => 0,
+    'title' => E::ts('Use CiviCRM invoice number when pushing to Xero'),
+    'description' => E::ts('When enabled, if the contribution has an invoice number it will be used as the Xero invoice number. If the contribution has no invoice number (or this setting is disabled) the invoice number is generated as (prefix + contribution ID).'),
+    'help_text' => '',
+    'html_type' => 'checkbox',
+    'settings_pages' => ['xero' => ['weight' => 2]],
+  ],
   'xero_default_invoice_status' => [
     'name' => 'xero_default_invoice_status',
     'type' => 'String',

--- a/tests/phpunit/Civi/InvoiceMappingTestable.php
+++ b/tests/phpunit/Civi/InvoiceMappingTestable.php
@@ -20,4 +20,8 @@ class InvoiceMappingTestable extends \CRM_Civixero_Invoice {
     return $this->mapCancelled($contributionID, $xeroInvoiceUUID);
   }
 
+  public function callIsContributionEligibleForPush(array $accountInvoice): bool {
+    return $this->isContributionEligibleForPush($accountInvoice);
+  }
+
 }

--- a/tests/phpunit/InvoiceMappingTest.php
+++ b/tests/phpunit/InvoiceMappingTest.php
@@ -36,6 +36,8 @@ class InvoiceMappingTest extends TestCase implements HeadlessInterface, HookInte
     // in from whatever this site's Contribute settings happen to be.
     Civi::settings()->set('invoice_due_date', 0);
     Civi::settings()->set('invoice_due_date_period', 'select');
+    // Pin to the default so tests that enable it can't leak into others.
+    Civi::settings()->set('xero_use_contribution_invoice_number', FALSE);
     parent::setUp();
   }
 
@@ -131,6 +133,30 @@ class InvoiceMappingTest extends TestCase implements HeadlessInterface, HookInte
 
     $result = $this->getInvoice()->callMapToAccounts($invoiceData, NULL);
     $this->assertEquals('Inclusive', $result[0]['LineAmountTypes']);
+  }
+
+  public function testMapToAccountsUsesContributionInvoiceNumberWhenSettingEnabled(): void {
+    Civi::settings()->set('xero_use_contribution_invoice_number', TRUE);
+    $invoiceData = $this->getBasicInvoiceData();
+    $invoiceData['invoice_number'] = 'INV-2024-0042';
+
+    $result = $this->getInvoice()->callMapToAccounts($invoiceData, NULL);
+    $this->assertEquals('INV-2024-0042', $result[0]['InvoiceNumber']);
+  }
+
+  public function testMapToAccountsIgnoresContributionInvoiceNumberWhenSettingDisabled(): void {
+    Civi::settings()->set('xero_use_contribution_invoice_number', FALSE);
+    $invoiceData = $this->getBasicInvoiceData();
+    $invoiceData['invoice_number'] = 'INV-2024-0042';
+
+    $result = $this->getInvoice()->callMapToAccounts($invoiceData, NULL);
+    $this->assertEquals('CIVI123', $result[0]['InvoiceNumber']);
+  }
+
+  public function testMapToAccountsFallsBackToPrefixWhenNoContributionInvoiceNumber(): void {
+    Civi::settings()->set('xero_use_contribution_invoice_number', TRUE);
+    $result = $this->getInvoice()->callMapToAccounts($this->getBasicInvoiceData(), NULL);
+    $this->assertEquals('CIVI123', $result[0]['InvoiceNumber']);
   }
 
   public function testMapCancelledWithoutUuid(): void {

--- a/tests/phpunit/InvoicePushEligibilityTest.php
+++ b/tests/phpunit/InvoicePushEligibilityTest.php
@@ -1,0 +1,159 @@
+<?php
+
+use Civi\Api4\Contact;
+use Civi\Api4\Contribution;
+use Civi\Api4\PaymentProcessor;
+use Civi\InvoiceMappingTestable;
+use Civi\MockConnector;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the push-time re-check of the accountsync queue-time settings
+ * (CRM_Civixero_Invoice::isContributionEligibleForPush()).
+ *
+ * @group headless
+ */
+class InvoicePushEligibilityTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->install('org.civicrm.search_kit')
+      ->install('nz.co.fuzion.accountsync')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp(): void {
+    Civi::$statics['civixero_connector'] = new MockConnector();
+    // Neutralise all three settings so each test enables only what it needs.
+    Civi::settings()->set('account_sync_push_contribution_status', []);
+    Civi::settings()->set('account_sync_contribution_day_zero', '');
+    Civi::settings()->set('account_sync_skip_inv_by_pymt_processor', []);
+    parent::setUp();
+  }
+
+  private function getInvoice(): InvoiceMappingTestable {
+    return new InvoiceMappingTestable([]);
+  }
+
+  private function createContribution(string $status = 'Pending', string $receiveDate = '2024-03-15 10:00:00'): int {
+    $contactID = Contact::create(FALSE)
+      ->addValue('contact_type', 'Individual')
+      ->addValue('first_name', 'Push')
+      ->addValue('last_name', 'Eligibility')
+      ->execute()
+      ->first()['id'];
+
+    return Contribution::create(FALSE)
+      ->addValue('contact_id', $contactID)
+      ->addValue('financial_type_id.name', 'Donation')
+      ->addValue('total_amount', 100.00)
+      ->addValue('receive_date', $receiveDate)
+      ->addValue('contribution_status_id:name', $status)
+      ->execute()
+      ->first()['id'];
+  }
+
+  private function getStatusID(string $status): int {
+    return (int) CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $status);
+  }
+
+  public function testEligibleWhenNoSettingsConfigured(): void {
+    $contributionID = $this->createContribution('Completed');
+
+    $this->assertTrue($this->getInvoice()->callIsContributionEligibleForPush(['contribution_id' => $contributionID]));
+  }
+
+  public function testIneligibleWhenStatusNotEnabled(): void {
+    Civi::settings()->set('account_sync_push_contribution_status', [$this->getStatusID('Pending')]);
+    $contributionID = $this->createContribution('Completed');
+
+    $this->assertFalse($this->getInvoice()->callIsContributionEligibleForPush(['contribution_id' => $contributionID]));
+  }
+
+  public function testEligibleWhenStatusEnabled(): void {
+    Civi::settings()->set('account_sync_push_contribution_status', [$this->getStatusID('Pending')]);
+    $contributionID = $this->createContribution('Pending');
+
+    $this->assertTrue($this->getInvoice()->callIsContributionEligibleForPush(['contribution_id' => $contributionID]));
+  }
+
+  public function testIneligibleWhenReceivedBeforeDayZero(): void {
+    Civi::settings()->set('account_sync_contribution_day_zero', '2023-01-01');
+    $contributionID = $this->createContribution('Pending', '2020-06-01 10:00:00');
+
+    $this->assertFalse($this->getInvoice()->callIsContributionEligibleForPush(['contribution_id' => $contributionID]));
+  }
+
+  public function testEligibleWhenReceivedAfterDayZero(): void {
+    Civi::settings()->set('account_sync_contribution_day_zero', '2023-01-01');
+    $contributionID = $this->createContribution('Pending', '2024-06-01 10:00:00');
+
+    $this->assertTrue($this->getInvoice()->callIsContributionEligibleForPush(['contribution_id' => $contributionID]));
+  }
+
+  public function testUnparseableDayZeroDoesNotBlockPush(): void {
+    Civi::settings()->set('account_sync_contribution_day_zero', 'not-a-date');
+    $contributionID = $this->createContribution('Pending', '2020-06-01 10:00:00');
+
+    $this->assertTrue($this->getInvoice()->callIsContributionEligibleForPush(['contribution_id' => $contributionID]));
+  }
+
+  public function testIneligibleWhenPaidViaSkippedPaymentProcessor(): void {
+    $processorID = $this->createDummyPaymentProcessor();
+    Civi::settings()->set('account_sync_skip_inv_by_pymt_processor', [$processorID]);
+    $contributionID = $this->createContribution('Pending');
+    civicrm_api3('Payment', 'create', [
+      'contribution_id' => $contributionID,
+      'total_amount' => 100.00,
+      'payment_processor_id' => $processorID,
+      'is_send_contribution_notification' => 0,
+    ]);
+
+    $this->assertFalse($this->getInvoice()->callIsContributionEligibleForPush(['contribution_id' => $contributionID]));
+  }
+
+  public function testEligibleWhenPaidViaOtherPaymentProcessor(): void {
+    $skippedProcessorID = $this->createDummyPaymentProcessor('skipped_dummy');
+    $usedProcessorID = $this->createDummyPaymentProcessor('used_dummy');
+    Civi::settings()->set('account_sync_skip_inv_by_pymt_processor', [$skippedProcessorID]);
+    $contributionID = $this->createContribution('Pending');
+    civicrm_api3('Payment', 'create', [
+      'contribution_id' => $contributionID,
+      'total_amount' => 100.00,
+      'payment_processor_id' => $usedProcessorID,
+      'is_send_contribution_notification' => 0,
+    ]);
+
+    $this->assertTrue($this->getInvoice()->callIsContributionEligibleForPush(['contribution_id' => $contributionID]));
+  }
+
+  public function testEligibleWhenContributionMissing(): void {
+    Civi::settings()->set('account_sync_push_contribution_status', [$this->getStatusID('Pending')]);
+
+    // A deleted contribution is left to the existing error handling downstream.
+    $this->assertTrue($this->getInvoice()->callIsContributionEligibleForPush(['contribution_id' => 9999999]));
+  }
+
+  public function testEligibleWhenNoContributionID(): void {
+    Civi::settings()->set('account_sync_push_contribution_status', [$this->getStatusID('Pending')]);
+
+    $this->assertTrue($this->getInvoice()->callIsContributionEligibleForPush([]));
+  }
+
+  private function createDummyPaymentProcessor(string $name = 'eligibility_dummy'): int {
+    return (int) PaymentProcessor::create(FALSE)
+      ->addValue('name', $name)
+      ->addValue('title', $name)
+      ->addValue('payment_processor_type_id:name', 'Dummy')
+      ->addValue('financial_account_id:name', 'Payment Processor Account')
+      ->addValue('is_active', TRUE)
+      ->execute()
+      ->first()['id'];
+  }
+
+}


### PR DESCRIPTION
## Overview

Re-checks the accountsync queue-time settings at Xero push time, so a contribution that changed after being queued is no longer pushed against the configured rules. The settings involved are `account_sync_push_contribution_status` (Push Contribution Status), `account_sync_contribution_day_zero` (Day zero for contributions) and `account_sync_skip_inv_by_pymt_processor` (Skip invoice creation by payment processor), all defined in nz.co.fuzion.accountsync.

## Before

The three settings are only evaluated by accountsync's `hook_civicrm_post` at the moment a contribution is queued into `civicrm_account_invoice`. The push job (`Civixero.invoicepush`) pushes anything queued without re-checking, so a contribution whose state changed between queueing and pushing still reaches Xero. Example: with Push Contribution Status set to Pending only, a contribution created through the backoffice form is briefly saved as Pending (queued), then completed by the payment — and is pushed to Xero even though Completed is not an enabled status.

## After

Each queued record is re-validated against the contribution's **current** state immediately before push:

- **Push Contribution Status** — the contribution's current status must be one of the enabled statuses.
- **Day zero** — contributions received before the configured date are never pushed.
- **Skip by payment processor** — contributions paid via one of the configured processors are not pushed.

A contribution failing any check is **dequeued** (`accounts_needs_update = 0`) with an info-level log stating which rule skipped it. This is not treated as an error (no `error_data`), and if a later edit makes the contribution eligible again, accountsync's post hook re-queues it as normal. Settings that are empty/unset impose no filter, matching queue-time behaviour.

## Technical Details

- New `CRM_Civixero_Invoice::isContributionEligibleForPush()` called at the top of the push loop; ineligible records are dequeued and skipped before any Xero API call is made.
- The status check uses the same loose `in_array()` semantics as accountsync's queue-time check, so stored value formats behave identically in both places.
- The day-zero comparison uses `DateTime` rather than `strtotime()`: an unparseable date logs a warning and does not block the push (fail-open), instead of silently misbehaving.
- The payment-processor check deliberately diverges from accountsync's implementation: accountsync inspects a transient BAO property that only exists during payment-processor form flows and is unavailable at push time, so this check reads the `payment_processor_id` recorded on the contribution's financial transactions (via `EntityFinancialTrxn`) instead.
- `CRM_Civixero_BankTransaction` inherits `push()`, so bank-transaction push is subject to the same checks.
- Cost: one `Contribution::get` per queued record, plus one transaction lookup only when the skip-by-processor setting is populated — proportional to queue size, not to total invoice volume.

## Behaviour change note

This is an intentional behaviour change: contributions that previously "leaked" to Xero after changing state post-queueing will now be skipped. Sites relying on the old push-anyway behaviour should review their Push Contribution Status configuration before upgrading. Manual single-contribution pushes (`Civixero.invoicepush` with a `contribution_id` parameter) are also subject to the checks.

## Tests

New headless tests in `tests/phpunit/InvoicePushEligibilityTest.php` (10 tests):

- No settings configured → eligible (no filter applied).
- Status not enabled → ineligible; status enabled → eligible.
- Received before day zero → ineligible; after → eligible; unparseable day-zero value → does not block (logged warning instead).
- Paid via a skipped payment processor → ineligible; paid via a different processor → eligible (exercises the real `Payment.create` → `EntityFinancialTrxn` path with Dummy processors).
- Deleted contribution or record without a `contribution_id` → eligible (left to existing downstream handling).

Existing tests pass unchanged.

## Comments
This issue is described [here](https://github.com/eileenmcnaughton/nz.co.fuzion.civixero/issues/219) and  this is based on [this](https://github.com/eileenmcnaughton/nz.co.fuzion.civixero/pull/220) PR as we needed a single commit that has both the changes to refer to