### PR TITLE
Fix Contact push() crash on hook-vetoed mapping

### DIFF
--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -276,11 +276,18 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
 
         $xeroContactUUID = !empty($record['accounts_contact_id']) ? $record['accounts_contact_id'] : NULL;
         $accountsContact = $this->mapToAccounts($contact, $xeroContactUUID);
-        $result = $this->pushToXero($accountsContact, $params['connector_id']);
-        $responseErrors = $result === FALSE ? [] : $this->validateResponse($result);
-        if ($result === FALSE) {
-          unset($record['accounts_modified_date']);
+        if ($accountsContact === FALSE) {
+          // Hook vetoed the push - not a real error, so mark it resolved.
+          AccountContact::update(FALSE)
+            ->addWhere('id', '=', $record['id'])
+            ->addValue('error_data', json_encode(['error' => 'Ignored via accountPushAlterMapped hook']))
+            ->addValue('is_error_resolved', TRUE)
+            ->addValue('accounts_needs_update', FALSE)
+            ->execute();
+          continue;
         }
+        $result = $this->pushToXero($accountsContact, $params['connector_id']);
+        $responseErrors = $this->validateResponse($result);
         if ($responseErrors) {
           $record['error_data'] = json_encode($responseErrors);
           throw new CRM_Core_Exception('Error in response from Xero');
@@ -367,24 +374,16 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
   /**
    * Push a single mapped contact to Xero.
    *
-   * The only method the Xero-SDK migration touches - push()'s surrounding
-   * orchestration (error handling, throttle abort, DB updates) does not
-   * care which client this delegates to underneath.
-   *
-   * @param array|bool $accountsContact
-   *   Mapped contact array as produced by mapToAccounts(), or FALSE if a
-   *   hook vetoed the push.
+   * @param array $accountsContact
+   *   Mapped contact array as produced by mapToAccounts().
    * @param int $connector_id
    *
-   * @return array|bool
-   *   FALSE if $accountsContact was FALSE, otherwise the raw Xero response.
+   * @return array
+   *   The raw Xero response.
    *
    * @throws \CRM_Core_Exception
    */
-  protected function pushToXero($accountsContact, $connector_id) {
-    if ($accountsContact === FALSE) {
-      return FALSE;
-    }
+  protected function pushToXero(array $accountsContact, $connector_id) {
     try {
       return $this->pushViaApi($accountsContact);
     }

--- a/tests/phpunit/Civi/ContactPushTestable.php
+++ b/tests/phpunit/Civi/ContactPushTestable.php
@@ -23,14 +23,8 @@ class ContactPushTestable extends \CRM_Civixero_Contact {
    */
   public array $pushToXeroCalls = [];
 
-  protected function pushToXero($accountsContact, $connector_id) {
+  protected function pushToXero(array $accountsContact, $connector_id) {
     $this->pushToXeroCalls[] = $accountsContact;
-    // Preserve the real pushToXero()'s short-circuit: push() itself never
-    // checks $accountsContact for FALSE before calling pushToXero(), so
-    // this behaviour has to live here too, not just in the real method.
-    if ($accountsContact === FALSE) {
-      return FALSE;
-    }
     if ($this->pushToXeroQueue === []) {
       throw new \LogicException('ContactPushTestable::pushToXero() called with nothing queued');
     }

--- a/tests/phpunit/ContactPushTest.php
+++ b/tests/phpunit/ContactPushTest.php
@@ -340,44 +340,23 @@ class ContactPushTest extends TestCase implements HeadlessInterface, HookInterfa
     $this->assertNotEmpty(Civi::settings()->get('xero_oauth_rate_exceeded'));
   }
 
-  /**
-   * mapToAccounts() returning FALSE (hook veto via accountPushAlterMapped)
-   * pins down a genuine PRE-EXISTING bug, confirmed here rather than fixed:
-   * pushToXero() correctly short-circuits to FALSE without consulting the
-   * queue, but push() itself never checks for that FALSE before using it as
-   * an array (unlike Invoice::push(), which checks $mappedAccountInvoice for
-   * FALSE/NULL before calling pushToXero() at all). The dedupe-lookup on
-   * $result['Contacts']['Contact']['ContactID'] then reads array offsets off
-   * a boolean, which PHPUnit's error handler escalates into a thrown
-   * ErrorException - so the record ends up recorded as a push FAILURE
-   * (error_data set, is_error_resolved cleared) instead of being skipped
-   * cleanly. Out of scope to fix here (the SDK migration only touches
-   * pushToXero()), but worth flagging as a small, separate bugfix.
-   */
   public function testPushSkipsContactWhenMapToAccountsHookVetoes(): void {
     $fixture = $this->createQueuedAccountContact();
     $this->vetoPush = TRUE;
     $contact = new ContactPushTestable([]);
-    // pushToXero() itself still gets called with $accountsContact === FALSE
-    // and correctly short-circuits to FALSE without consulting the queue -
-    // nothing needs to be queued for it.
 
-    try {
-      $contact->push(['connector_id' => 0], 10);
-      $this->fail('Expected push() to throw - see docblock above for why this is a pre-existing bug, not the intended behaviour');
-    }
-    catch (CRM_Core_Exception $e) {
-      $this->assertStringContainsString('Not all contacts were saved', $e->getMessage());
-    }
+    $result = $contact->push(['connector_id' => 0], 10);
 
-    $this->assertCount(1, $contact->pushToXeroCalls);
-    $this->assertFalse($contact->pushToXeroCalls[0]);
+    $this->assertTrue($result);
+    $this->assertCount(0, $contact->pushToXeroCalls);
     $saved = \Civi\Api4\AccountContact::get(FALSE)
       ->addWhere('id', '=', $fixture['account_contact_id'])
       ->execute()
       ->single();
-    $this->assertNotEmpty($saved['error_data']);
-    $this->assertStringContainsString('Trying to access array offset on false', $saved['error_data']);
+    $this->assertStringContainsString('Ignored via accountPushAlterMapped hook', $saved['error_data']);
+    // The hook explicitly chose to exclude this contact - not a real error.
+    $this->assertEquals(1, $saved['is_error_resolved']);
+    $this->assertEquals(0, $saved['accounts_needs_update']);
   }
 
 }


### PR DESCRIPTION
## Bug

`mapToAccounts()` returns `FALSE` when `accountPushAlterMapped` vetoes a contact, but `push()` read array offsets off that `FALSE` in the dedupe-lookup, recording it as a push failure instead of skipping it.

## Fix

`push()` now checks for the veto before calling `pushToXero()` at all, matching the `is_deleted` branch above it: skips cleanly, clears `accounts_needs_update`, records an informative `error_data`, and marks `is_error_resolved = TRUE` (a hook explicitly excluding a contact isn't a real error - same design used for Invoice's no-op cases in #194).

Since `pushToXero()` can now never be called with `FALSE`, removed that dead branch from it and from `ContactPushTestable`, tightening both to a plain `array` parameter.

## Tests

Replaced the characterization test with one asserting the fixed (clean-skip) behaviour. Full civixero suite passing (76/76), civilint clean relative to this diff.