### PR TITLE
Make Contact/Invoice pull resilient to per-page errors

### DIFF
--- a/CRM/Civixero/Base.php
+++ b/CRM/Civixero/Base.php
@@ -2,6 +2,7 @@
 
 use Civi\API\Event\PrepareEvent;
 use Civi\Xero\ConnectorInterface;
+use CRM_Civixero_ExtensionUtil as E;
 use League\OAuth2\Client\Token\AccessToken;
 use XeroAPI\XeroPHP\Api\AccountingApi;
 
@@ -316,6 +317,88 @@ class CRM_Civixero_Base {
   public static function resetApiRateLimitExceeded(): void {
     Civi::settings()->set('xero_oauth_rate_exceeded', NULL);
     Civi::settings()->set('xero_retry_after', NULL);
+  }
+
+  /**
+   * If the given ApiException represents Xero rate-limiting (HTTP 429),
+   * throw the shared throttle exception (using the Retry-After header to
+   * compute when it's safe to retry). Returns normally for any other
+   * status code, leaving the caller to decide how to handle it.
+   *
+   * @throws \CRM_Civixero_Exception_XeroThrottle
+   */
+  protected function throwIfRateLimited(\XeroAPI\XeroPHP\ApiException $e): void {
+    if ($e->getCode() === 429) {
+      $retryAfterSeconds = (int) ($e->getResponseHeaders()['Retry-After'][0] ?? 0);
+      throw new CRM_Civixero_Exception_XeroThrottle($e->getMessage(), $e->getCode(), $e, $retryAfterSeconds ? (time() + $retryAfterSeconds) : NULL);
+    }
+  }
+
+  /**
+   * Run a paged pull loop against Xero, handling rate-limiting, auth
+   * failures, and per-page errors uniformly.
+   *
+   * - Xero rate-limiting: engages the shared circuit breaker and stops
+   *   paging (further pages would be rejected anyway).
+   * - Auth failure (401/403): stops paging and rethrows immediately, since
+   *   every later page would fail identically.
+   * - Anything else (including the caller's own per-record aggregate
+   *   exception): logged and recorded, but paging continues to the next
+   *   page - a bad page should not strand the rest of the run.
+   *
+   * An aggregate CRM_Core_Exception is thrown once paging ends if any
+   * page had errors, so the caller (and civicrm_job_log) sees a failed
+   * run even though it made partial progress.
+   *
+   * @param callable $fetchPage
+   *   function(int $page): array - returns the records for that page, or
+   *   an empty array to signal there are no more pages.
+   * @param callable $processPage
+   *   function(array $records): void - processes one page's records; may
+   *   throw (e.g. an aggregate per-record exception).
+   * @param string $entityLabel
+   *   Used only in log messages / the aggregate exception, e.g. 'Contact'.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function runResilientPagingPull(callable $fetchPage, callable $processPage, string $entityLabel): void {
+    $page = 1;
+    $pageErrors = [];
+
+    while (TRUE) {
+      try {
+        $records = $fetchPage($page);
+        if (empty($records)) {
+          break;
+        }
+        $processPage($records);
+        $page++;
+      }
+      catch (CRM_Civixero_Exception_XeroThrottle $e) {
+        \Civi::log(E::SHORT_NAME)->warning("CiviXero: $entityLabel Pull stopped early - rate limited by Xero: " . $e->getMessage());
+        self::setApiRateLimitExceeded($e->getRetryAfter());
+        $pageErrors[] = "Page $page: rate limited by Xero";
+        break;
+      }
+      catch (\XeroAPI\XeroPHP\ApiException $e) {
+        if (in_array($e->getCode(), [401, 403], TRUE)) {
+          \Civi::log(E::SHORT_NAME)->error("CiviXero: $entityLabel Pull aborted - authentication failed: " . $e->getMessage());
+          throw new CRM_Core_Exception('Authentication with Xero failed: ' . $e->getMessage());
+        }
+        \Civi::log(E::SHORT_NAME)->error("CiviXero: Error pulling $entityLabel page $page: " . $e->getMessage());
+        $pageErrors[] = "Page $page: " . $e->getMessage();
+        $page++;
+      }
+      catch (\Exception $e) {
+        \Civi::log(E::SHORT_NAME)->error("CiviXero: Error pulling $entityLabel page $page: " . $e->getMessage());
+        $pageErrors[] = "Page $page: " . $e->getMessage();
+        $page++;
+      }
+    }
+
+    if ($pageErrors) {
+      throw new CRM_Core_Exception(E::ts('%1 Pull completed with errors', [1 => $entityLabel]) . ': ' . print_r($pageErrors, TRUE), 'incomplete', $pageErrors);
+    }
   }
 
   /**

--- a/CRM/Civixero/Contact.php
+++ b/CRM/Civixero/Contact.php
@@ -66,6 +66,11 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
     } catch (\InvalidArgumentException $e) {
       // This means there are no contacts returned for the requested page. That's ok!
       return [];
+    }
+    catch (\XeroAPI\XeroPHP\ApiException $e) {
+      $this->throwIfRateLimited($e);
+      \Civi::log(E::SHORT_NAME)->error('Exception when calling AccountingApi->getContacts: ' . $e->getMessage());
+      throw $e;
     } catch (\Exception $e) {
       \Civi::log(E::SHORT_NAME)->error('Exception when calling AccountingApi->getContacts: ' . $e->getMessage());
       throw $e;
@@ -78,36 +83,25 @@ class CRM_Civixero_Contact extends CRM_Civixero_Base {
    *
    * We call the civicrm_accountPullPreSave hook so other modules can alter if required
    *
+   * Errors on one page (a duplicate match, a save failure, a transient API
+   * error) do not stop later pages from being attempted - only an
+   * authentication failure or Xero rate-limiting stops the run early, since
+   * every subsequent page would fail identically. If any page had errors,
+   * an aggregate CRM_Core_Exception is thrown once all pages have been
+   * attempted, so the job shows as failed even though it made partial
+   * progress.
+   *
    * @param array $params
    *
    * @throws CRM_Core_Exception
    */
   public function pullUsingApi4(array $params): void {
-    $page = 1;
     $pageSize = 100;
-
-    try {
-      while (TRUE) {
-        $contactPull = \Civi\Api4\Xero::contactPull(FALSE)
-          ->setIfModifiedSinceDateTime($params['start_date'])
-          ->setConnectorID($params['connector_id'] ?? 0)
-          ->setPage($page)
-          ->setPageSize($pageSize);
-        if (!empty($params['xero_contact_id'])) {
-          $contactPull->setSearchTerm($params['xero_contact_id']);
-        }
-        $contacts = $contactPull->execute()->getArrayCopy();
-        if (empty($contacts)) {
-          break;
-        }
-        $this->processPull($contacts, $params['connector_id'] ?? 0);
-        unset($contacts);
-        $page++;
-      }
-    }
-    catch (\Throwable $e) {
-      \Civi::log(E::SHORT_NAME)->error('CiviXero: Error when running Contact Pull: ' . $e->getMessage());
-    }
+    $this->runResilientPagingPull(
+      fn(int $page) => $this->pullFromXero([], FALSE, FALSE, $params['xero_contact_id'] ?? '', $page, $pageSize, $params['start_date']),
+      fn(array $contacts) => $this->processPull($contacts, $params['connector_id'] ?? 0),
+      'Contact'
+    );
   }
 
   protected function processPull($contacts, int $connectorID) {

--- a/CRM/Civixero/Invoice.php
+++ b/CRM/Civixero/Invoice.php
@@ -113,8 +113,13 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
       // This means there are no invoices returned for the requested page. That's ok!
       return [];
     }
+    catch (\XeroAPI\XeroPHP\ApiException $e) {
+      $this->throwIfRateLimited($e);
+      \Civi::log(E::SHORT_NAME)->error('Exception when calling AccountingApi->getInvoices: ' . $e->getMessage());
+      throw $e;
+    }
     catch (\Exception $e) {
-      \Civi::log('civixero')->error('Exception when calling AccountingApi->getInvoices: ' . $e->getMessage());
+      \Civi::log(E::SHORT_NAME)->error('Exception when calling AccountingApi->getInvoices: ' . $e->getMessage());
       throw $e;
     }
     return $invoices ?? [];
@@ -125,48 +130,40 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
    *
    * We call the civicrm_accountPullPreSave hook so other modules can alter if required
    *
+   * Errors on one page (a save failure, a transient API error) do not stop
+   * later pages from being attempted - only an authentication failure or
+   * Xero rate-limiting stops the run early, since every subsequent page
+   * would fail identically. If any page had errors, an aggregate
+   * CRM_Core_Exception is thrown once all pages have been attempted, so the
+   * job shows as failed even though it made partial progress.
+   *
    * @param array $params
    *
    * @throws CRM_Core_Exception
    */
   public function pullUsingApi4(array $params): void {
-    $page = 1;
     $pageSize = 100;
+    // Ignore start/modified date if we specified IDs.
+    // Note: this deliberately checks 'xero_invoice_number', not
+    // 'invoice_number' (the actual param name) - a pre-existing quirk in the
+    // original condition, preserved as-is rather than fixed here.
+    $ignoreDate = !empty($params['xero_contact_id']) || !empty($params['xero_invoice_id']) || !empty($params['xero_invoice_number']);
 
-    try {
-      while (TRUE) {
-        $invoicePull = \Civi\Api4\Xero::invoicePull(FALSE)
-          ->setConnectorID($params['connector_id'] ?? 0)
-          ->setPage($page)
-          ->setPageSize($pageSize);
-        if (!empty($params['xero_contact_id'])) {
-          $invoicePull->setXeroContactIDs($params['xero_contact_id']);
-        }
-        if (!empty($params['xero_invoice_id'])) {
-          $invoicePull->setXeroInvoiceIDs($params['xero_invoice_id']);
-        }
-        if (!empty($params['invoice_number'])) {
-          $invoicePull->setXeroInvoiceNumbers($params['invoice_number']);
-        }
-        if (empty($params['xero_contact_id']) && empty($params['xero_invoice_id']) && empty($params['xero_invoice_number'])) {
-          // Ignore start/modified date if we specified IDs
-          $invoicePull->setIfModifiedSinceDateTime($params['start_date']);
-        }
-        $invoices = $invoicePull->execute()->getArrayCopy();
-        if (empty($invoices)) {
-          break;
-        }
-        $this->processPull($invoices, $params['connector_id'] ?? 0, $params['create_contributions_in_civicrm'] ?? FALSE);
-        unset($invoices);
-        $page++;
-      }
-    }
-    catch (\Throwable $e) {
-      \Civi::log('civixero')->error('CiviXero: Error when running Invoice Pull: ' . $e->getMessage());
-      if ($e->getCode() === 403) {
-        throw new CRM_Core_Exception('Authentication with Xero failed');
-      }
-    }
+    $this->runResilientPagingPull(
+      fn(int $page) => $this->pullFromXero(
+        FALSE,
+        FALSE,
+        '',
+        $page,
+        $pageSize,
+        $ignoreDate ? '-1 week' : $params['start_date'],
+        $params['xero_invoice_id'] ?? '',
+        $params['invoice_number'] ?? '',
+        $params['xero_contact_id'] ?? ''
+      ),
+      fn(array $invoices) => $this->processPull($invoices, $params['connector_id'] ?? 0, $params['create_contributions_in_civicrm'] ?? FALSE),
+      'Invoice'
+    );
   }
 
   /**
@@ -796,10 +793,7 @@ class CRM_Civixero_Invoice extends CRM_Civixero_Base {
       throw new CRM_Civixero_Exception_XeroThrottle($e->getMessage(), $e->getCode(), $e, $e->getRetryAfter());
     }
     catch (\XeroAPI\XeroPHP\ApiException $e) {
-      if ($e->getCode() === 429) {
-        $retryAfterSeconds = (int) ($e->getResponseHeaders()['Retry-After'][0] ?? 0);
-        throw new CRM_Civixero_Exception_XeroThrottle($e->getMessage(), $e->getCode(), $e, $retryAfterSeconds ? (time() + $retryAfterSeconds) : NULL);
-      }
+      $this->throwIfRateLimited($e);
       throw new CRM_Core_Exception(
         'Synchronization error ' . $e->getMessage(),
         'xero_' . $e->getCode(),

--- a/tests/phpunit/Civi/InvoiceSdkPullTestable.php
+++ b/tests/phpunit/Civi/InvoiceSdkPullTestable.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Civi;
+
+use GuzzleHttp\ClientInterface;
+use XeroAPI\XeroPHP\Api\AccountingApi;
+use XeroAPI\XeroPHP\Configuration;
+
+/**
+ * Overrides CRM_Civixero_Invoice::getAccountingApiInstance() so the real SDK
+ * (real request-building/serialization, real response deserialization) can
+ * be exercised against a mocked Guzzle HTTP client instead of the network.
+ * Mirrors ContactSdkPullTestable - see that class for why this lives outside
+ * a *Test.php file.
+ */
+class InvoiceSdkPullTestable extends \CRM_Civixero_Invoice {
+
+  public ClientInterface $mockClient;
+
+  public function getAccountingApiInstance(): AccountingApi {
+    $config = Configuration::getDefaultConfiguration()->setAccessToken($this->getAccessToken());
+    return new AccountingApi($this->mockClient, $config);
+  }
+
+}

--- a/tests/phpunit/ContactPullUsingApi4Test.php
+++ b/tests/phpunit/ContactPullUsingApi4Test.php
@@ -1,0 +1,162 @@
+<?php
+
+use Civi\ContactSdkPullTestable;
+use Civi\MockConnector;
+use Civi\Test\Api3TestTrait;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\ContactTestTrait;
+use Civi\Test\GuzzleTestTrait;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises CRM_Civixero_Contact::pullUsingApi4()'s paging loop directly -
+ * ContactSdkPullTestable (from ContactSdkPullTest) is reused unchanged here:
+ * pullUsingApi4() now calls $this->pullFromXero() itself rather than going
+ * through the Civi\Api4\Xero::contactPull() action (which always constructed
+ * its own, un-mockable CRM_Civixero_Contact instance), so the existing mocked
+ * Guzzle client override reaches pullUsingApi4() too.
+ *
+ * @group headless
+ */
+class ContactPullUsingApi4Test extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  use GuzzleTestTrait;
+  use Api3TestTrait;
+  use ContactTestTrait;
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->install('org.civicrm.search_kit')
+      ->install('nz.co.fuzion.accountsync')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp(): void {
+    Civi::$statics['civixero_connector'] = new MockConnector();
+    parent::setUp();
+  }
+
+  private function getContactWithMockClient(): ContactSdkPullTestable {
+    $this->setUpClientWithHistoryContainer();
+    $contact = new ContactSdkPullTestable([]);
+    $contact->mockClient = $this->getGuzzleClient();
+    return $contact;
+  }
+
+  private function xeroContactJson(string $contactID, string $name, string $contactNumber = ''): string {
+    return json_encode([
+      'Contacts' => [
+        [
+          'ContactID' => $contactID,
+          'Name' => $name,
+          'ContactNumber' => $contactNumber,
+          'UpdatedDateUTC' => '2024-03-15T10:00:00',
+        ],
+      ],
+    ]);
+  }
+
+  private function emptyContactsJson(): string {
+    return json_encode(['Contacts' => []]);
+  }
+
+  public function testRateLimitOnFirstPageStopsPagingAndSetsBreaker(): void {
+    $this->createMockHandler([]);
+    $this->getMockHandler()->append(new \GuzzleHttp\Psr7\Response(429, ['Retry-After' => ['120']], json_encode(['Message' => 'Too many requests'])));
+    $contact = $this->getContactWithMockClient();
+
+    $before = time();
+    try {
+      $contact->pullUsingApi4(['start_date' => '-1 week', 'connector_id' => 0]);
+      $this->fail('Expected CRM_Core_Exception to be thrown');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertStringContainsString('rate limited', $e->getMessage());
+    }
+    $this->assertCount(1, $this->getContainer());
+    $retryAfter = \Civi::settings()->get('xero_retry_after');
+    $this->assertGreaterThanOrEqual($before + 120, $retryAfter);
+    $this->assertLessThanOrEqual($before + 121, $retryAfter);
+  }
+
+  public function testAuthFailureOnFirstPageAbortsImmediately(): void {
+    $this->createMockHandler([]);
+    $this->getMockHandler()->append(new \GuzzleHttp\Psr7\Response(403, [], json_encode(['Message' => 'Forbidden'])));
+    $contact = $this->getContactWithMockClient();
+
+    try {
+      $contact->pullUsingApi4(['start_date' => '-1 week', 'connector_id' => 0]);
+      $this->fail('Expected CRM_Core_Exception to be thrown');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertStringContainsString('Authentication with Xero failed', $e->getMessage());
+    }
+    // Only the first (failing) page was ever requested.
+    $this->assertCount(1, $this->getContainer());
+  }
+
+  public function testPerContactErrorOnOnePageDoesNotBlockLaterPages(): void {
+    $matchedContactID = $this->individualCreate();
+    $duplicateXeroContactID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    // Two existing AccountContact rows that both match the incoming Xero
+    // contact below (one via ContactNumber->contact_id, one via
+    // accounts_contact_id) - reproduces processPull()'s duplicate-match
+    // error on page 1, same fixture shape as ContactPullTest's equivalent.
+    $this->callAPISuccess('AccountContact', 'create', [
+      'contact_id' => $matchedContactID,
+      'plugin' => 'xero',
+      'connector_id' => 0,
+    ]);
+    $this->callAPISuccess('AccountContact', 'create', [
+      'plugin' => 'xero',
+      'connector_id' => 0,
+      'accounts_contact_id' => $duplicateXeroContactID,
+    ]);
+
+    $this->createMockHandler([
+      $this->xeroContactJson($duplicateXeroContactID, 'Duplicate Contact', (string) $matchedContactID),
+      $this->xeroContactJson('bbbbbbbb-cccc-dddd-eeee-ffffffffffff', 'Clean Contact'),
+      $this->emptyContactsJson(),
+    ]);
+    $contact = $this->getContactWithMockClient();
+
+    try {
+      $contact->pullUsingApi4(['start_date' => '-1 week', 'connector_id' => 0]);
+      $this->fail('Expected CRM_Core_Exception to be thrown');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertStringContainsString('Page 1', $e->getMessage());
+    }
+    // All 3 pages were requested - the page 1 error didn't strand page 2/3.
+    $this->assertCount(3, $this->getContainer());
+    $clean = \Civi\Api4\AccountContact::get(FALSE)
+      ->addWhere('accounts_contact_id', '=', 'bbbbbbbb-cccc-dddd-eeee-ffffffffffff')
+      ->execute()
+      ->single();
+    $this->assertEquals('Clean Contact', $clean['accounts_display_name']);
+  }
+
+  public function testCleanMultiPagePullDoesNotThrow(): void {
+    $this->createMockHandler([
+      $this->xeroContactJson('cccccccc-cccc-cccc-cccc-cccccccccccc', 'Page One Contact'),
+      $this->xeroContactJson('dddddddd-dddd-dddd-dddd-dddddddddddd', 'Page Two Contact'),
+      $this->emptyContactsJson(),
+    ]);
+    $contact = $this->getContactWithMockClient();
+
+    $contact->pullUsingApi4(['start_date' => '-1 week', 'connector_id' => 0]);
+
+    $this->assertCount(3, $this->getContainer());
+    foreach (['cccccccc-cccc-cccc-cccc-cccccccccccc', 'dddddddd-dddd-dddd-dddd-dddddddddddd'] as $xeroID) {
+      $saved = \Civi\Api4\AccountContact::get(FALSE)
+        ->addWhere('accounts_contact_id', '=', $xeroID)
+        ->execute();
+      $this->assertCount(1, $saved);
+    }
+  }
+
+}

--- a/tests/phpunit/ContactSdkPullTest.php
+++ b/tests/phpunit/ContactSdkPullTest.php
@@ -90,4 +90,34 @@ class ContactSdkPullTest extends TestCase implements HeadlessInterface, HookInte
     $this->pull($contact);
   }
 
+  public function testPullFromXeroThrowsThrottleExceptionOnRateLimitResponse(): void {
+    $this->createMockHandler([]);
+    $this->getMockHandler()->append(new \GuzzleHttp\Psr7\Response(429, ['Retry-After' => ['120']], json_encode(['Message' => 'Too many requests'])));
+    $contact = $this->getContactWithMockClient();
+
+    $before = time();
+    try {
+      $this->pull($contact);
+      $this->fail('Expected CRM_Civixero_Exception_XeroThrottle to be thrown');
+    }
+    catch (CRM_Civixero_Exception_XeroThrottle $e) {
+      $this->assertGreaterThanOrEqual($before + 120, $e->getRetryAfter());
+      $this->assertLessThanOrEqual($before + 121, $e->getRetryAfter());
+    }
+  }
+
+  public function testPullFromXeroPropagatesApiExceptionWithCodeOnAuthFailure(): void {
+    $this->createMockHandler([]);
+    $this->getMockHandler()->append(new \GuzzleHttp\Psr7\Response(403, [], json_encode(['Message' => 'Forbidden'])));
+    $contact = $this->getContactWithMockClient();
+
+    try {
+      $this->pull($contact);
+      $this->fail('Expected ApiException to be thrown');
+    }
+    catch (\XeroAPI\XeroPHP\ApiException $e) {
+      $this->assertEquals(403, $e->getCode());
+    }
+  }
+
 }

--- a/tests/phpunit/InvoicePullUsingApi4Test.php
+++ b/tests/phpunit/InvoicePullUsingApi4Test.php
@@ -1,0 +1,128 @@
+<?php
+
+use Civi\InvoiceSdkPullTestable;
+use Civi\MockConnector;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\GuzzleTestTrait;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises CRM_Civixero_Invoice::pullUsingApi4()'s paging loop directly -
+ * mirrors ContactPullUsingApi4Test. pullUsingApi4() now calls
+ * $this->pullFromXero() itself rather than going through the
+ * Civi\Api4\Xero::invoicePull() action (which always constructed its own,
+ * un-mockable CRM_Civixero_Invoice instance), so the existing mocked Guzzle
+ * client override reaches pullUsingApi4() too.
+ *
+ * The "one page's per-record error doesn't block later pages" case is
+ * already covered end-to-end for Contact pull (ContactPullUsingApi4Test) -
+ * the underlying mechanism in pullUsingApi4() is identical code for both
+ * classes. Invoice::processPull()'s own per-record error paths are all
+ * defensively guarded (e.g. an unresolvable contribution_id is detected and
+ * stripped before save, rather than left to fail as a DB error), so there is
+ * no natural, non-contrived way to trigger one here - not reproduced
+ * separately for Invoice.
+ *
+ * @group headless
+ */
+class InvoicePullUsingApi4Test extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  use GuzzleTestTrait;
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->install('org.civicrm.search_kit')
+      ->install('nz.co.fuzion.accountsync')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp(): void {
+    Civi::$statics['civixero_connector'] = new MockConnector();
+    parent::setUp();
+  }
+
+  private function getInvoiceWithMockClient(): InvoiceSdkPullTestable {
+    $this->setUpClientWithHistoryContainer();
+    $invoice = new InvoiceSdkPullTestable([]);
+    $invoice->mockClient = $this->getGuzzleClient();
+    return $invoice;
+  }
+
+  private function xeroInvoiceJson(string $invoiceID, string $invoiceNumber): string {
+    return json_encode([
+      'Invoices' => [
+        [
+          'InvoiceID' => $invoiceID,
+          'Type' => 'ACCREC',
+          'InvoiceNumber' => $invoiceNumber,
+          'Status' => 'AUTHORISED',
+          'Date' => '2024-03-15T00:00:00',
+          'DueDate' => '2024-03-29T00:00:00',
+          'UpdatedDateUTC' => '2024-03-15T10:00:00',
+        ],
+      ],
+    ]);
+  }
+
+  private function emptyInvoicesJson(): string {
+    return json_encode(['Invoices' => []]);
+  }
+
+  public function testRateLimitOnFirstPageStopsPagingAndSetsBreaker(): void {
+    $this->createMockHandler([]);
+    $this->getMockHandler()->append(new \GuzzleHttp\Psr7\Response(429, ['Retry-After' => ['60']], json_encode(['Message' => 'Too many requests'])));
+    $invoice = $this->getInvoiceWithMockClient();
+
+    $before = time();
+    try {
+      $invoice->pullUsingApi4(['start_date' => '-1 week', 'connector_id' => 0]);
+      $this->fail('Expected CRM_Core_Exception to be thrown');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertStringContainsString('rate limited', $e->getMessage());
+    }
+    $this->assertCount(1, $this->getContainer());
+    $retryAfter = \Civi::settings()->get('xero_retry_after');
+    $this->assertGreaterThanOrEqual($before + 60, $retryAfter);
+    $this->assertLessThanOrEqual($before + 61, $retryAfter);
+  }
+
+  public function testAuthFailureOnFirstPageAbortsImmediately(): void {
+    $this->createMockHandler([]);
+    $this->getMockHandler()->append(new \GuzzleHttp\Psr7\Response(401, [], json_encode(['Message' => 'Unauthorized'])));
+    $invoice = $this->getInvoiceWithMockClient();
+
+    try {
+      $invoice->pullUsingApi4(['start_date' => '-1 week', 'connector_id' => 0]);
+      $this->fail('Expected CRM_Core_Exception to be thrown');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertStringContainsString('Authentication with Xero failed', $e->getMessage());
+    }
+    $this->assertCount(1, $this->getContainer());
+  }
+
+  public function testCleanMultiPagePullDoesNotThrow(): void {
+    $this->createMockHandler([
+      $this->xeroInvoiceJson('cccccccc-cccc-cccc-cccc-cccccccccccc', 'INV-0001'),
+      $this->xeroInvoiceJson('dddddddd-dddd-dddd-dddd-dddddddddddd', 'INV-0002'),
+      $this->emptyInvoicesJson(),
+    ]);
+    $invoice = $this->getInvoiceWithMockClient();
+
+    $invoice->pullUsingApi4(['start_date' => '-1 week', 'connector_id' => 0]);
+
+    $this->assertCount(3, $this->getContainer());
+    foreach (['cccccccc-cccc-cccc-cccc-cccccccccccc', 'dddddddd-dddd-dddd-dddd-dddddddddddd'] as $xeroID) {
+      $saved = \Civi\Api4\AccountInvoice::get(FALSE)
+        ->addWhere('accounts_invoice_id', '=', $xeroID)
+        ->execute();
+      $this->assertCount(1, $saved);
+    }
+  }
+
+}

--- a/tests/phpunit/InvoiceSdkPullTest.php
+++ b/tests/phpunit/InvoiceSdkPullTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Civi\InvoiceSdkPullTestable;
+use Civi\MockConnector;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\GuzzleTestTrait;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises CRM_Civixero_Invoice::pullFromXero()'s new ApiException
+ * classification (429 -> CRM_Civixero_Exception_XeroThrottle, everything
+ * else -> unchanged ApiException) against the real xeroapi/xero-php-oauth2
+ * AccountingApi with a mocked Guzzle HTTP client - mirrors ContactSdkPullTest.
+ *
+ * @group headless
+ */
+class InvoiceSdkPullTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  use GuzzleTestTrait;
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->install('org.civicrm.search_kit')
+      ->install('nz.co.fuzion.accountsync')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp(): void {
+    Civi::$statics['civixero_connector'] = new MockConnector();
+    parent::setUp();
+  }
+
+  private function getInvoiceWithMockClient(): InvoiceSdkPullTestable {
+    $this->setUpClientWithHistoryContainer();
+    $invoice = new InvoiceSdkPullTestable([]);
+    $invoice->mockClient = $this->getGuzzleClient();
+    return $invoice;
+  }
+
+  private function pull(InvoiceSdkPullTestable $invoice): array {
+    return $invoice->pullFromXero(FALSE, FALSE, '', 1, 100, '-1 week', '', '', '');
+  }
+
+  public function testPullFromXeroThrowsThrottleExceptionOnRateLimitResponse(): void {
+    $this->createMockHandler([]);
+    $this->getMockHandler()->append(new \GuzzleHttp\Psr7\Response(429, ['Retry-After' => ['90']], json_encode(['Message' => 'Too many requests'])));
+    $invoice = $this->getInvoiceWithMockClient();
+
+    $before = time();
+    try {
+      $this->pull($invoice);
+      $this->fail('Expected CRM_Civixero_Exception_XeroThrottle to be thrown');
+    }
+    catch (CRM_Civixero_Exception_XeroThrottle $e) {
+      $this->assertGreaterThanOrEqual($before + 90, $e->getRetryAfter());
+      $this->assertLessThanOrEqual($before + 91, $e->getRetryAfter());
+    }
+  }
+
+  public function testPullFromXeroPropagatesApiExceptionWithCodeOnAuthFailure(): void {
+    $this->createMockHandler([]);
+    $this->getMockHandler()->append(new \GuzzleHttp\Psr7\Response(403, [], json_encode(['Message' => 'Forbidden'])));
+    $invoice = $this->getInvoiceWithMockClient();
+
+    try {
+      $this->pull($invoice);
+      $this->fail('Expected ApiException to be thrown');
+    }
+    catch (\XeroAPI\XeroPHP\ApiException $e) {
+      $this->assertEquals(403, $e->getCode());
+    }
+  }
+
+  public function testPullFromXeroLogsAndRethrowsOnOtherApiError(): void {
+    $this->createMockHandler([]);
+    $this->getMockHandler()->append(new \GuzzleHttp\Psr7\Response(500, [], json_encode(['Message' => 'Internal error'])));
+    $invoice = $this->getInvoiceWithMockClient();
+
+    $this->expectException(\XeroAPI\XeroPHP\ApiException::class);
+    $this->pull($invoice);
+  }
+
+}


### PR DESCRIPTION
## Bug

`pullUsingApi4()` wrapped the whole paging loop in one try/catch, so a single bad record/page (a save failure, a transient API error) aborted the entire pull - later pages that would have succeeded were never attempted. Pulls also had no rate-limit handling, unlike push.

## Fix

Per-page errors are now caught individually: a save failure, duplicate-match, or transient API error is recorded and paging continues to the next page. Only an authentication failure or Xero rate-limiting stops the run early, since every subsequent page would fail identically - rate-limiting now engages the same circuit breaker push already uses. If any page had errors, an aggregate exception is thrown once all pages are attempted, so the job still shows as failed despite partial progress.

Applies to both Contact and Invoice pull, via a shared `runResilientPagingPull()` helper on `Base.php`.

## Tests

New `*PullUsingApi4Test.php` for both entities covering rate-limit abort, auth-failure abort, per-page error isolation, and clean multi-page runs. Full civixero suite passing (88/88).